### PR TITLE
Feat/#1 implement headless interview bubble

### DIFF
--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -347,6 +347,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -376,6 +377,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Pressor/Pressor/Resources/RecordBubble.swift
+++ b/Pressor/Pressor/Resources/RecordBubble.swift
@@ -6,15 +6,170 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
+import AVFoundation
 
+/**
+ 인터뷰의 내용과 음성 컨트롤러를 담는 레코드 버블 입니다.
+ 해당 뷰는 반드시 "스크롤뷰 내부"에서 호출합니다.
+ 
+ - Author: Celan
+ */
 struct RecordBubble: View {
+//    @State var record: Record
+    @State var index: Int
+    @State var isInterviewer: Bool
+    @State private var text: String = ""
+    @State private var isEditing: Bool = false
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        if isInterviewer {
+            HStack(spacing: 10) {
+                // MARK: - Button
+                Rectangle()
+                    .fill(.clear)
+                    .frame(width: 44, height: 44)
+                    .overlay(alignment: .center) {
+                        Button {
+                            // TODO: - Play or Stop
+                        } label: {
+                            Image(systemName: "play.fill")
+                        }
+                        .frame(width: 34, height: 34)
+                        .background(Color.yellow)
+                        .clipShape(Circle())
+                    }
+                    .padding(.leading, 45)
+                
+                // MARK: - Bubble
+                VStack {
+                    if isEditing {
+                        TextField("", text: $text)
+                            .font(.system(size: 14))
+                            .frame(
+                                maxWidth: 278 - 39,
+                                minHeight: 44 - 22,
+                                alignment: .trailing
+                            )
+                            .padding(.vertical, 11)
+                            .padding(.horizontal, 19.5)
+                    } else {
+                        Text("\(record.recordDescription)")
+                            .font(.system(size: 14))
+                            .frame(
+                                maxWidth: 278 - 39,
+                                minHeight: 44 - 22,
+                                alignment: .trailing
+                            )
+                            .padding(.vertical, 11)
+                            .padding(.horizontal, 19.5)
+                    }
+                    
+                }
+                .background(Color.orange)
+                .clipShape(Bubble(isInterviewer: isInterviewer))
+                .frame(
+                    maxWidth: .infinity,
+                    alignment: .trailing
+                )
+                .contextMenu {
+                    Button {
+                        self.pasteToClipboard(with: record.recordDescription)
+                    } label: {
+                        Label("복사", systemImage: "doc.on.doc")
+                    }
+                    
+                    Button {
+                        withAnimation {
+                            isEditing.toggle()
+                        }
+                    } label: {
+                        Label("편집", systemImage: "square.and.pencil")
+                    }
+                }
+            }
+            .padding(.trailing, 16)
+            .padding(.bottom, 8)
+        } else {
+            HStack(spacing: 10) {
+                VStack {
+                    Text("RecordDescription Here.")
+                        .font(.system(size: 14))
+                        .frame(
+                            maxWidth: 278 - 39,
+                            minHeight: 44 - 22,
+                            alignment: .leading
+                        )
+                        .padding(.vertical, 11)
+                        .padding(.horizontal, 19.5)
+                }
+                .background(Color.green)
+                .clipShape(Bubble(isInterviewer: isInterviewer))
+                .frame(
+                    maxWidth: .infinity,
+                    alignment: .trailing
+                )
+                
+                Rectangle()
+                    .fill(.clear)
+                    .frame(width: 44, height: 44)
+                    .overlay(alignment: .center) {
+                        Button {
+                            print("재생")
+                        } label: {
+                            Image(systemName: "play.fill")
+                        }
+                        .frame(width: 34, height: 34)
+                        .background(.yellow)
+                        .clipShape(Circle())
+                    }
+                    .padding(.trailing, 45)
+            }
+            .padding(.leading, 16)
+            .padding(.bottom, 8)
+        }
+    }
+    
+    /**
+     Clipboard로 복사하는 메소드입니다.
+     완료되는 시점에 뷰에 복사 완료를 알리는 알람을 띄웁니다. <- Todo
+     */
+    private func pasteToClipboard(with str: String) {
+        UIPasteboard.general.setValue(
+            str,
+            forPasteboardType: UTType.plainText.identifier
+        )
+    }
+}
+
+struct Bubble: Shape {
+    var isInterviewer: Bool
+    
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners:
+                isInterviewer
+                ? [.topLeft, .bottomLeft, .bottomRight]
+                : [.topRight, .bottomRight, .bottomLeft]
+            ,
+            cornerRadii: CGSize(
+                width: 20,
+                height: 20
+            )
+        )
+        
+        return Path(path.cgPath)
     }
 }
 
 struct RecordBubble_Previews: PreviewProvider {
     static var previews: some View {
-        RecordBubble()
+        ScrollView {
+//            RecordBubble(record: .init(recordDescription: "하이하이"), index: 0, isInterviewer: true)
+//            RecordBubble(record: .init(recordDescription: "안녕안녕"), index: 1, isInterviewer: false)
+//            RecordBubble(record: .init(recordDescription: "바이바이"), index: 0, isInterviewer: true)
+//            RecordBubble(record: .init(recordDescription: "그래그래"), index: 2, isInterviewer: false)
+        }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
- #1 


## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

1. Headless Interview Bubble View 구현
2. Interview, Record Model 진행상황에 따라 play, stop, interviewInfoUpdate 등의 메소드를 추후 구현.

