### PR TITLE
Feat/#8 implement interview recording view

### DIFF
--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		7EDEB0D72A011E0E00176D72 /* RecordBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0D62A011E0E00176D72 /* RecordBubble.swift */; };
 		7EDEB0D92A011E1500176D72 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0D82A011E1500176D72 /* Record.swift */; };
 		7EDEB0DB2A011E2A00176D72 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */; };
+		C957BB9F2A027D05006649A8 /* InterviewRecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C957BB9E2A027D05006649A8 /* InterviewRecordingView.swift */; };
+		C957BBA12A028DDC006649A8 /* AudioInputVIewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C957BBA02A028DDC006649A8 /* AudioInputVIewModel.swift */; };
 		C9C7BC822A021F1F005E473B /* AudioVisualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */; };
 /* End PBXBuildFile section */
 
@@ -32,6 +34,8 @@
 		7EDEB0D62A011E0E00176D72 /* RecordBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBubble.swift; sourceTree = "<group>"; };
 		7EDEB0D82A011E1500176D72 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
+		C957BB9E2A027D05006649A8 /* InterviewRecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewRecordingView.swift; sourceTree = "<group>"; };
+		C957BBA02A028DDC006649A8 /* AudioInputVIewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputVIewModel.swift; sourceTree = "<group>"; };
 		C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVisualizerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -98,6 +102,7 @@
 			isa = PBXGroup;
 			children = (
 				7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */,
+				C957BBA02A028DDC006649A8 /* AudioInputVIewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -132,6 +137,7 @@
 			isa = PBXGroup;
 			children = (
 				7EDEB0D42A011DF600176D72 /* MainInterviewList.swift */,
+				C957BB9E2A027D05006649A8 /* InterviewRecordingView.swift */,
 			);
 			path = InterviewViews;
 			sourceTree = "<group>";
@@ -206,6 +212,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C957BBA12A028DDC006649A8 /* AudioInputVIewModel.swift in Sources */,
 				7EDEB0BF2A011B4B00176D72 /* ContentView.swift in Sources */,
 				7EDEB0D12A011DD100176D72 /* MainRecordView.swift in Sources */,
 				7EDEB0D32A011DE800176D72 /* AddRecordScriptModalView.swift in Sources */,
@@ -214,6 +221,7 @@
 				7EDEB0BD2A011B4B00176D72 /* PressorApp.swift in Sources */,
 				7EDEB0D92A011E1500176D72 /* Record.swift in Sources */,
 				7EDEB0D72A011E0E00176D72 /* RecordBubble.swift in Sources */,
+				C957BB9F2A027D05006649A8 /* InterviewRecordingView.swift in Sources */,
 				7EDEB0D52A011DF600176D72 /* MainInterviewList.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		7EDEB0D72A011E0E00176D72 /* RecordBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0D62A011E0E00176D72 /* RecordBubble.swift */; };
 		7EDEB0D92A011E1500176D72 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0D82A011E1500176D72 /* Record.swift */; };
 		7EDEB0DB2A011E2A00176D72 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */; };
+		C9C7BC822A021F1F005E473B /* AudioVisualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		7EDEB0D62A011E0E00176D72 /* RecordBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBubble.swift; sourceTree = "<group>"; };
 		7EDEB0D82A011E1500176D72 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
+		C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVisualizerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +123,7 @@
 			children = (
 				7EDEB0D02A011DD100176D72 /* MainRecordView.swift */,
 				7EDEB0D22A011DE800176D72 /* AddRecordScriptModalView.swift */,
+				C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */,
 			);
 			path = RecordViews;
 			sourceTree = "<group>";
@@ -206,6 +209,7 @@
 				7EDEB0BF2A011B4B00176D72 /* ContentView.swift in Sources */,
 				7EDEB0D12A011DD100176D72 /* MainRecordView.swift in Sources */,
 				7EDEB0D32A011DE800176D72 /* AddRecordScriptModalView.swift in Sources */,
+				C9C7BC822A021F1F005E473B /* AudioVisualizerView.swift in Sources */,
 				7EDEB0DB2A011E2A00176D72 /* RecordViewModel.swift in Sources */,
 				7EDEB0BD2A011B4B00176D72 /* PressorApp.swift in Sources */,
 				7EDEB0D92A011E1500176D72 /* Record.swift in Sources */,

--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -396,8 +396,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -428,8 +427,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -351,14 +351,16 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pressor/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = CV4G9J35Y5;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -380,14 +382,16 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pressor/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = CV4G9J35Y5;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Pressor/Pressor/ViewModels/AudioInputVIewModel.swift
+++ b/Pressor/Pressor/ViewModels/AudioInputVIewModel.swift
@@ -1,0 +1,63 @@
+//
+//  AudioInputVIewModel.swift
+//  Pressor
+//
+//  Created by Ha Jong Myeong on 2023/05/03.
+//
+
+import Foundation
+import AVFoundation
+
+// 오디오 입력을 처리하기 위한 뷰 모델 클래스
+class AudioInputViewModel: ObservableObject {
+    // AVAudioEngine을 사용하여 오디오 데이터를 처리
+    var audioEngine: AVAudioEngine
+    // 처리된 오디오 버퍼를 처리하는 핸들러
+    private var audioBufferHandler: ((AVAudioPCMBuffer) -> Void)?
+    
+    // AVAudioEngine 인스턴스 초기화
+    init() {
+        audioEngine = AVAudioEngine()
+    }
+
+    // 오디오 엔진을 준비하고 탭 설치
+    func prepare() {
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            self.audioBufferHandler?(buffer)
+        }
+    }
+    
+    // 오디오 녹음을 시작하고 오디오 버퍼 핸들러 설정
+    func startRecording(_ audioBufferHandler: @escaping (AVAudioPCMBuffer) -> Void) {
+        // 오디오 버퍼 핸들러 설정
+        self.audioBufferHandler = audioBufferHandler
+        // 기존 탭 제거
+        let inputNode = audioEngine.inputNode
+        inputNode.removeTap(onBus: 0)
+        
+        // 새 탭 설치
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            audioBufferHandler(buffer)
+        }
+        
+        // 오디오 엔진 준비
+        audioEngine.prepare()
+        
+        // 오디오 엔진 시작
+        do {
+            try audioEngine.start()
+        } catch {
+            print("Error starting the audio engine: \(error.localizedDescription)")
+        }
+    }
+    
+    // 오디오 녹음 중지 및 탭 제거
+    func stopRecording() {
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+    }
+}

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -12,17 +12,57 @@ struct InterviewRecordingView: View {
     @State private var isRecording = false
     @State private var isPaused = false
     @State private var duration: TimeInterval = 0.0
-
+    @State private var backgroundColor: Color = SpeakerColor.speakerOne
+    @State private var timer: Timer? = nil
+    @State private var rotationAngle: Double = 0
+    
+    // 화자 구분 색상
+    private struct SpeakerColor {
+           static let speakerOne = Color(red: 1, green: 234 / 255, blue: 132 / 255)
+           static let speakerTwo = Color(red: 177 / 255, green: 232 / 255, blue: 1)
+       }
+    
+    // 타이머 시작 함수
+    private func startTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
+            duration += 0.1
+        }
+    }
+    
+    // 타이머 중지 함수
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    // 타이머 초기화 함수
+    private func resetDuration() {
+        duration = 0
+    }
+    
+    // 타이머 일시정지 함수
+    private func pauseResumeTimer() {
+        if timer == nil {
+            startTimer()
+        } else {
+            stopTimer()
+        }
+    }
+    
     var body: some View {
         VStack {
             HStack {
                 Spacer()
                 Button(action: {
                     // 화면 플립 기능
+                    withAnimation(.easeInOut(duration: 0.6)) {
+                        rotationAngle += 180
+                    }
                 }) {
                     Image(systemName: "arrow.up.arrow.down.circle")
                         .resizable()
                         .frame(width: 40, height: 40)
+                        .foregroundColor(.black)
                 }
                 .padding()
             }
@@ -31,6 +71,7 @@ struct InterviewRecordingView: View {
             
             Button(action: {
                 // 화자 전환 기능
+                backgroundColor = backgroundColor == SpeakerColor.speakerOne ? SpeakerColor.speakerTwo : SpeakerColor.speakerOne
             }) {
                 RoundedRectangle(cornerRadius: 10)
                     .fill(Color.blue)
@@ -38,12 +79,16 @@ struct InterviewRecordingView: View {
             }
             
             Spacer()
-            AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording)
+            // 오디오 비쥬얼라이저 뷰
+            AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording, isPaused: $isPaused)
             HStack {
+                // 타이머 표시
                 Text(String(format: "%.1fs", duration))
                     .font(.title2)
+                    .frame(minWidth: 50)
                     .padding(.leading)
                 
+                // 녹음 버튼
                 Button(action: {
                     isRecording.toggle()
                     if isRecording {
@@ -52,8 +97,12 @@ struct InterviewRecordingView: View {
                                 // UI 관련 로직
                             }
                         }
+                        startTimer()
                     } else {
                         audioInputManager.stopRecording()
+                        isPaused = false
+                        stopTimer()
+                        resetDuration()
                     }
                 }) {
                     Image(systemName: isRecording ? "stop.circle" : "record.circle")
@@ -64,6 +113,7 @@ struct InterviewRecordingView: View {
                 
                 Button(action: {
                     isPaused.toggle()
+                    pauseResumeTimer()
                     if isPaused {
                         // 녹음 일시정지
                     } else {
@@ -74,10 +124,13 @@ struct InterviewRecordingView: View {
                         .resizable()
                         .frame(width: 60, height: 60)
                 }
+                .disabled(!isRecording)
                 .padding(.trailing)
             }
             .padding(.bottom)
         }
+        .rotation3DEffect(.degrees(rotationAngle), axis: (x: 1.0, y: 0.0, z: 0.0))
+        .background(backgroundColor)
         .onAppear {
             audioInputManager.prepare()
         }
@@ -86,6 +139,7 @@ struct InterviewRecordingView: View {
         }
     }
 }
+
 
 struct InterviewRecordingView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -10,17 +10,26 @@ import SwiftUI
 struct InterviewRecordingView: View {
     @StateObject private var audioInputManager = AudioInputViewModel()
     @State private var isRecording = false
-    @State private var isPaused = false
+    @State private var isPaused = true
     @State private var duration: TimeInterval = 0.0
-    @State private var backgroundColor: Color = SpeakerColor.speakerOne
+    @State private var speakerSwitch: Color = SpeakerSwitch.speakerOne
     @State private var timer: Timer? = nil
-    @State private var rotationAngle: Double = 0
+    @State private var visualColor: Color = Color(red: 1.0, green: 166/255, blue: 0.0)
+    
+    // 타이머 시간 포맷
+    func formattedDuration(_ duration: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = .pad
+        return formatter.string(from: duration) ?? "00:00"
+    }
     
     // 화자 구분 색상
-    private struct SpeakerColor {
-           static let speakerOne = Color(red: 1, green: 234 / 255, blue: 132 / 255)
-           static let speakerTwo = Color(red: 177 / 255, green: 232 / 255, blue: 1)
-       }
+    private struct SpeakerSwitch {
+        static let speakerOne = Color(red: 0.0, green: 234/255, blue: 223/255)
+        static let speakerTwo = Color(red: 1.0, green: 166/255, blue: 0.0)
+    }
     
     // 타이머 시작 함수
     private func startTimer() {
@@ -50,95 +59,179 @@ struct InterviewRecordingView: View {
     }
     
     var body: some View {
-        VStack {
-            HStack {
-                Spacer()
-                Button(action: {
-                    // 화면 플립 기능
-                    withAnimation(.easeInOut(duration: 0.6)) {
-                        rotationAngle += 180
-                    }
-                }) {
-                    Image(systemName: "arrow.up.arrow.down.circle")
-                        .resizable()
-                        .frame(width: 40, height: 40)
-                        .foregroundColor(.black)
-                }
-                .padding()
-            }
-            
-            Spacer()
-            
-            Button(action: {
-                // 화자 전환 기능
-                backgroundColor = backgroundColor == SpeakerColor.speakerOne ? SpeakerColor.speakerTwo : SpeakerColor.speakerOne
-            }) {
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.blue)
-                    .frame(width: 100, height: 300)
-            }
-            
-            Spacer()
-            // 오디오 비쥬얼라이저 뷰
-            AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording, isPaused: $isPaused)
-            HStack {
-                // 타이머 표시
-                Text(String(format: "%.1fs", duration))
-                    .font(.title2)
-                    .frame(minWidth: 50)
-                    .padding(.leading)
-                
-                // 녹음 버튼
-                Button(action: {
-                    isRecording.toggle()
-                    if isRecording {
-                        audioInputManager.startRecording { buffer in
-                            DispatchQueue.main.async {
-                                // UI 관련 로직
+        ZStack { // 백그라운드 컬러
+            Color.black.ignoresSafeArea()
+            VStack { // 컨트롤 영역 + 화자전환 영역 + 오디오 비주얼라이저 영역
+                HStack { // 컨트롤 영역 (일시정지 및 재생 + 완료)
+                    
+                    // 일시정지 및 재생 버튼의 좌측 마진 Spacer
+                    Spacer()
+                        .frame(width: 131)
+                    
+                    // 일시정지 및 재생 버튼 로직
+                    Button(action: {
+                        isRecording.toggle()
+                            if isRecording {
+                                // 녹음 중일때 -> 녹음 시작 및 타이머 시작
+                                isPaused = false
+                                audioInputManager.startRecording { buffer in
+                                    DispatchQueue.main.async {
+                                        // UI 관련 로직
+                                    }
+                                }
+                                startTimer()
+                                // 녹음 중일때 or 일시정지일 떄 오디오 비주얼라이저 색상 변경
+                                if speakerSwitch == SpeakerSwitch.speakerOne {
+                                    visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
+                                } else {
+                                    visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
+                                }
+                            } else {
+                                // 일시정지일때 -> 타이머 정지 및 오디오 비주얼라이저 끔
+                                audioInputManager.stopRecording()
+                                isPaused = true
+                                stopTimer()
+                                // 오디오 비주얼라이저 회색으로 비활성화 표시
+                                visualColor = Color.gray
                             }
+                    }) {
+                        // 일시정지 및 재생 버튼 UI
+                        RoundedRectangle(cornerRadius: 35)
+                            // 버튼 겉 stroke
+                            .stroke(!isPaused ? Color.white : Color.red, lineWidth: 3)
+                            .frame(width: 131, height: 44)
+                            .padding(.top, 16)
+                            // 버튼 속 fill
+                            .overlay(RoundedRectangle(cornerRadius: 35)
+                                .frame(width: 119, height: 32)
+                                .padding(.top, 16)
+                                // 녹음 중일때 -> 검정색, 녹음 일시정지일때 -> 빨간색
+                                .foregroundColor(!isPaused ? Color.black : Color(red: 1.0, green: 0.0, blue: 0.0, opacity: 30/100))
+                                .overlay(
+                                    HStack {
+                                        // 녹음 중일때 -> 일시정지 심볼, 녹음 일시정지일때 -> 재생 심볼
+                                        Image(systemName: !isPaused ? "pause.fill" : "play.fill")
+                                            .resizable()
+                                            .frame(width: 18, height: 18)
+                                            .foregroundColor(Color.red)
+                                            .padding(.top, 16)
+                                        // 타이머 텍스트
+                                        Text(formattedDuration(duration))
+                                            .font(.title2)
+                                            .fontDesign(.rounded)
+                                            .fontWeight(.bold)
+                                            .foregroundColor(!isPaused ? Color.white : Color.red)
+                                            .frame(minWidth: 50)
+                                            .padding(.top, 16)
+                                    }
+                                )
+                            )
+                    }
+                    
+                    // 일시정지 및 재생 버튼과 완료 버튼 사이 마진 Spacer
+                    Spacer()
+                        .frame(width: 56)
+                    
+                    // 완료 버튼 로직
+                    Button(action: {
+                            // 타이머 초기화
+                            resetDuration()
+                        }) {
+                            // 완료 버튼 UI
+                            Text("완료")
+                                .font(.headline)
+                                // 녹음 중일때 -> 회색, 녹음 일시정지일때 -> 빨간색
+                                .foregroundColor(!isPaused ? Color(red: 117/255, green: 117/255, blue: 117/255) : Color.red)
+                                .padding(.top, 16)
                         }
-                        startTimer()
-                    } else {
-                        audioInputManager.stopRecording()
-                        isPaused = false
-                        stopTimer()
-                        resetDuration()
-                    }
-                }) {
-                    Image(systemName: isRecording ? "stop.circle" : "record.circle")
-                        .resizable()
-                        .frame(width: 60, height: 60)
-                        .foregroundColor(.red)
-                }
+                    // 녹음 중일 때 완료 버튼 비활성화
+                    .disabled(isRecording)
+                    .padding(.trailing)
+                    
+                    // 완료 버튼 우측 마진 Spacer
+                    Spacer()
+                        .frame(width: 28)
+                } // 컨트롤 영역 (일시정지 및 재생 + 완료) HStack 닫기
+                    
+                //상단의 컨트롤영역과 중앙의 화자전환영역 사이 마진 Spacer
+                Spacer()
+                    .frame(height: 22)
+                                    
+                    // 화자 전환 기능
+                    RoundedRectangle(cornerRadius: 44)
+                        // 화자전환 영역
+                        .fill(Color(red: 28/255, green: 28/255, blue: 30/255))
+                        .frame(width: 391, height: 680)
+                        // 화자전환 제스처
+                        .gesture(
+                            DragGesture(minimumDistance: 100, coordinateSpace: .local)
+                                .onChanged { value in
+                                    let isDraggingDownward = value.translation.height > 100
+                                    withAnimation() {
+                                        if isDraggingDownward {
+                                            // 오디오 비주얼라이저 색상
+                                            speakerSwitch = SpeakerSwitch.speakerOne
+                                            visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
+                                        } else {
+                                            // 오디오 비주얼라이저 색상
+                                            speakerSwitch = SpeakerSwitch.speakerTwo
+                                            visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
+                                        }
+                                    }
+                                }
+                        )
+                        // 화자전환 가이드
+                        .overlay(
+                            Group {
+                                if speakerSwitch == SpeakerSwitch.speakerOne {
+                                    // 내가 화자일때
+                                    VStack {
+                                        Spacer()
+                                            .frame(height: 480)
+                                        Image(systemName: "chevron.compact.up")
+                                            .resizable()
+                                            .frame(width: 34, height: 10)
+                                            .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
+                                            .padding(.bottom, 10)
+                                        Text("쓸어올려 상대로 전환")
+                                            .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
+                                    }
+                                } else {
+                                    // 상대가 화자일때
+                                    VStack{
+                                        Spacer()
+                                            .frame(height: 480)
+                                        Image(systemName: "chevron.compact.down")
+                                            .resizable()
+                                            .frame(width: 34, height: 10)
+                                            .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
+                                            .padding(.bottom, 10)
+                                        Text("쓸어내려 나로 전환")
+                                            .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
+                                    }
+                                }
+                            }
+                                .font(.headline)
+                                .fontWeight(.bold)
+                        )
+                    
+                // 화자전환 영역과 오디오 비주얼라이저 사이 마진 Spacer
+                Spacer()
                 
-                Button(action: {
-                    isPaused.toggle()
-                    pauseResumeTimer()
-                    if isPaused {
-                        // 녹음 일시정지
-                    } else {
-                        // 녹음 재개
-                    }
-                }) {
-                    Image(systemName: isPaused ? "play.circle" : "pause.circle")
-                        .resizable()
-                        .frame(width: 60, height: 60)
-                }
-                .disabled(!isRecording)
-                .padding(.trailing)
+                // 오디오 비쥬얼라이저 뷰
+                AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording, isPaused: $isPaused, audioVisualizerColor: $visualColor)
+                    .padding()
+                    
+            } // 컨트롤영역 + 화자전환영역 + 오디오 비주얼라이저 VStack 닫기
+            .onAppear {
+                audioInputManager.prepare()
             }
-            .padding(.bottom)
-        }
-        .rotation3DEffect(.degrees(rotationAngle), axis: (x: 1.0, y: 0.0, z: 0.0))
-        .background(backgroundColor)
-        .onAppear {
-            audioInputManager.prepare()
-        }
-        .onDisappear {
-            audioInputManager.stopRecording()
-        }
-    }
-}
+            .onDisappear {
+                audioInputManager.stopRecording()
+            }
+        } // 배경영역 + 기능영역(컨트롤영역 + 화자전환영역 + 오디오 비주얼라이저) ZStack 닫기
+    } // body
+} // struct
 
 
 struct InterviewRecordingView_Previews: PreviewProvider {
@@ -146,4 +239,3 @@ struct InterviewRecordingView_Previews: PreviewProvider {
         InterviewRecordingView()
     }
 }
-

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -1,0 +1,95 @@
+//
+//  InterviewRecordingView.swift
+//  Pressor
+//
+//  Created by Ha Jong Myeong on 2023/05/03.
+//
+
+import SwiftUI
+
+struct InterviewRecordingView: View {
+    @StateObject private var audioInputManager = AudioInputViewModel()
+    @State private var isRecording = false
+    @State private var isPaused = false
+    @State private var duration: TimeInterval = 0.0
+
+    var body: some View {
+        VStack {
+            HStack {
+                Spacer()
+                Button(action: {
+                    // 화면 플립 기능
+                }) {
+                    Image(systemName: "arrow.up.arrow.down.circle")
+                        .resizable()
+                        .frame(width: 40, height: 40)
+                }
+                .padding()
+            }
+            
+            Spacer()
+            
+            Button(action: {
+                // 화자 전환 기능
+            }) {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.blue)
+                    .frame(width: 100, height: 300)
+            }
+            
+            Spacer()
+            AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording)
+            HStack {
+                Text(String(format: "%.1fs", duration))
+                    .font(.title2)
+                    .padding(.leading)
+                
+                Button(action: {
+                    isRecording.toggle()
+                    if isRecording {
+                        audioInputManager.startRecording { buffer in
+                            DispatchQueue.main.async {
+                                // UI 관련 로직
+                            }
+                        }
+                    } else {
+                        audioInputManager.stopRecording()
+                    }
+                }) {
+                    Image(systemName: isRecording ? "stop.circle" : "record.circle")
+                        .resizable()
+                        .frame(width: 60, height: 60)
+                        .foregroundColor(.red)
+                }
+                
+                Button(action: {
+                    isPaused.toggle()
+                    if isPaused {
+                        // 녹음 일시정지
+                    } else {
+                        // 녹음 재개
+                    }
+                }) {
+                    Image(systemName: isPaused ? "play.circle" : "pause.circle")
+                        .resizable()
+                        .frame(width: 60, height: 60)
+                }
+                .padding(.trailing)
+            }
+            .padding(.bottom)
+        }
+        .onAppear {
+            audioInputManager.prepare()
+        }
+        .onDisappear {
+            audioInputManager.stopRecording()
+        }
+    }
+}
+
+struct InterviewRecordingView_Previews: PreviewProvider {
+    static var previews: some View {
+        InterviewRecordingView()
+    }
+}
+

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -59,183 +59,181 @@ struct InterviewRecordingView: View {
     }
     
     var body: some View {
-        ZStack { // 백그라운드 컬러
-            Color.black.ignoresSafeArea()
-            VStack { // 컨트롤 영역 + 화자전환 영역 + 오디오 비주얼라이저 영역
-                HStack { // 컨트롤 영역 (일시정지 및 재생 + 완료)
-                    
-                    // 일시정지 및 재생 버튼의 좌측 마진 Spacer
-                    Spacer()
-                        .frame(width: 131)
-                    
-                    // 일시정지 및 재생 버튼 로직
-                    Button(action: {
-                        isRecording.toggle()
-                            if isRecording {
-                                // 녹음 중일때 -> 녹음 시작 및 타이머 시작
-                                isPaused = false
-                                audioInputManager.startRecording { buffer in
-                                    DispatchQueue.main.async {
-                                        // UI 관련 로직
-                                    }
+        VStack { // 컨트롤 영역 + 화자전환 영역 + 오디오 비주얼라이저 영역
+            HStack { // 컨트롤 영역 (일시정지 및 재생 + 완료)
+                // 일시정지 및 재생 버튼의 좌측 마진 Spacer
+                // 일시정지 및 재생 버튼 로직
+                Button(action: {
+                    isRecording.toggle()
+                    if isRecording {
+                        // 녹음 중일때 -> 녹음 시작 및 타이머 시작
+                        isPaused = false
+                        audioInputManager.startRecording { buffer in
+                            DispatchQueue.main.async {
+                                // UI 관련 로직
+                            }
+                        }
+                        startTimer()
+                        // 녹음 중일때 or 일시정지일 떄 오디오 비주얼라이저 색상 변경
+                        if speakerSwitch == SpeakerSwitch.speakerOne {
+                            visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
+                        } else {
+                            visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
+                        }
+                    } else {
+                        // 일시정지일때 -> 타이머 정지 및 오디오 비주얼라이저 끔
+                        audioInputManager.stopRecording()
+                        isPaused = true
+                        stopTimer()
+                        // 오디오 비주얼라이저 회색으로 비활성화 표시
+                        visualColor = Color.gray
+                    }
+                }) {
+                    // 일시정지 및 재생 버튼 UI
+                    RoundedRectangle(cornerRadius: 35)
+                    // 버튼 겉 stroke
+                        .stroke(!isPaused ? Color.white : Color.red, lineWidth: 3)
+                        .frame(width: 131, height: 44)
+                        .padding(.top, 16)
+                    // 버튼 속 fill
+                        .overlay(RoundedRectangle(cornerRadius: 35)
+                            .frame(width: 119, height: 32)
+                            .padding(.top, 16)
+                                 // 녹음 중일때 -> 검정색, 녹음 일시정지일때 -> 빨간색
+                            .foregroundColor(!isPaused ? Color.black : Color(red: 1.0, green: 0.0, blue: 0.0, opacity: 30/100))
+                            .overlay(
+                                HStack {
+                                    // 녹음 중일때 -> 일시정지 심볼, 녹음 일시정지일때 -> 재생 심볼
+                                    Image(systemName: !isPaused ? "pause.fill" : "play.fill")
+                                        .resizable()
+                                        .frame(width: 18, height: 18)
+                                        .foregroundColor(Color.red)
+                                        .padding(.top, 16)
+                                    // 타이머 텍스트
+                                    Text(formattedDuration(duration))
+                                        .font(.title2)
+                                        .fontDesign(.rounded)
+                                        .fontWeight(.bold)
+                                        .foregroundColor(!isPaused ? Color.white : Color.red)
+                                        .frame(minWidth: 50)
+                                        .padding(.top, 16)
                                 }
-                                startTimer()
-                                // 녹음 중일때 or 일시정지일 떄 오디오 비주얼라이저 색상 변경
-                                if speakerSwitch == SpeakerSwitch.speakerOne {
+                            )
+                        )
+                }
+                .position(
+                    x: UIScreen.main.bounds.width / 2,
+                    y: UIScreen.main.bounds.height * 0.01
+                )
+                
+                // 완료 버튼 로직
+                Button(action: {
+                    // 타이머 초기화
+                    resetDuration()
+                }) {
+                    // 완료 버튼 UI
+                    Text("완료")
+                        .font(.headline)
+                    // 녹음 중일때 -> 회색, 녹음 일시정지일때 -> 빨간색
+                        .foregroundColor(!isPaused ? Color(red: 117/255, green: 117/255, blue: 117/255) : Color.red)
+                        .padding(.top, 16)
+                }
+                // 녹음 중일 때 완료 버튼 비활성화
+                .disabled(isRecording)
+//                .padding(.trailing, 24)
+                .position(
+                    x: UIScreen.main.bounds.width / 3,
+                    y: UIScreen.main.bounds.height * 0.01
+                )
+                
+                // 완료 버튼 우측 마진 Spacer
+//                Spacer()
+//                    .frame(width: 28)
+            } // 컨트롤 영역 (일시정지 및 재생 + 완료) HStack 닫기
+            .padding(.top, 8)
+            
+            // 화자 전환 기능
+            RoundedRectangle(cornerRadius: 44)
+            // 화자전환 영역
+                .fill(Color(red: 28/255, green: 28/255, blue: 30/255))
+                .frame(
+                    width: UIScreen.main.bounds.width * 0.95,
+                    height: UIScreen.main.bounds.height * 0.7
+                )
+            // 화자전환 제스처
+                .gesture(
+                    DragGesture(minimumDistance: 100, coordinateSpace: .local)
+                        .onChanged { value in
+                            let isDraggingDownward = value.translation.height > 100
+                            withAnimation() {
+                                if isDraggingDownward {
+                                    // 오디오 비주얼라이저 색상
+                                    speakerSwitch = SpeakerSwitch.speakerOne
                                     visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
                                 } else {
+                                    // 오디오 비주얼라이저 색상
+                                    speakerSwitch = SpeakerSwitch.speakerTwo
                                     visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
                                 }
-                            } else {
-                                // 일시정지일때 -> 타이머 정지 및 오디오 비주얼라이저 끔
-                                audioInputManager.stopRecording()
-                                isPaused = true
-                                stopTimer()
-                                // 오디오 비주얼라이저 회색으로 비활성화 표시
-                                visualColor = Color.gray
                             }
-                    }) {
-                        // 일시정지 및 재생 버튼 UI
-                        RoundedRectangle(cornerRadius: 35)
-                            // 버튼 겉 stroke
-                            .stroke(!isPaused ? Color.white : Color.red, lineWidth: 3)
-                            .frame(width: 131, height: 44)
-                            .padding(.top, 16)
-                            // 버튼 속 fill
-                            .overlay(RoundedRectangle(cornerRadius: 35)
-                                .frame(width: 119, height: 32)
-                                .padding(.top, 16)
-                                // 녹음 중일때 -> 검정색, 녹음 일시정지일때 -> 빨간색
-                                .foregroundColor(!isPaused ? Color.black : Color(red: 1.0, green: 0.0, blue: 0.0, opacity: 30/100))
-                                .overlay(
-                                    HStack {
-                                        // 녹음 중일때 -> 일시정지 심볼, 녹음 일시정지일때 -> 재생 심볼
-                                        Image(systemName: !isPaused ? "pause.fill" : "play.fill")
-                                            .resizable()
-                                            .frame(width: 18, height: 18)
-                                            .foregroundColor(Color.red)
-                                            .padding(.top, 16)
-                                        // 타이머 텍스트
-                                        Text(formattedDuration(duration))
-                                            .font(.title2)
-                                            .fontDesign(.rounded)
-                                            .fontWeight(.bold)
-                                            .foregroundColor(!isPaused ? Color.white : Color.red)
-                                            .frame(minWidth: 50)
-                                            .padding(.top, 16)
-                                    }
-                                )
-                            )
-                    }
-                    
-                    // 일시정지 및 재생 버튼과 완료 버튼 사이 마진 Spacer
-                    Spacer()
-                        .frame(width: 56)
-                    
-                    // 완료 버튼 로직
-                    Button(action: {
-                            // 타이머 초기화
-                            resetDuration()
-                        }) {
-                            // 완료 버튼 UI
-                            Text("완료")
-                                .font(.headline)
-                                // 녹음 중일때 -> 회색, 녹음 일시정지일때 -> 빨간색
-                                .foregroundColor(!isPaused ? Color(red: 117/255, green: 117/255, blue: 117/255) : Color.red)
-                                .padding(.top, 16)
                         }
-                    // 녹음 중일 때 완료 버튼 비활성화
-                    .disabled(isRecording)
-                    .padding(.trailing)
-                    
-                    // 완료 버튼 우측 마진 Spacer
-                    Spacer()
-                        .frame(width: 28)
-                } // 컨트롤 영역 (일시정지 및 재생 + 완료) HStack 닫기
-                    
-                //상단의 컨트롤영역과 중앙의 화자전환영역 사이 마진 Spacer
-                Spacer()
-                    .frame(height: 22)
-                                    
-                    // 화자 전환 기능
-                    RoundedRectangle(cornerRadius: 44)
-                        // 화자전환 영역
-                        .fill(Color(red: 28/255, green: 28/255, blue: 30/255))
-                        .frame(width: 391, height: 680)
-                        // 화자전환 제스처
-                        .gesture(
-                            DragGesture(minimumDistance: 100, coordinateSpace: .local)
-                                .onChanged { value in
-                                    let isDraggingDownward = value.translation.height > 100
-                                    withAnimation() {
-                                        if isDraggingDownward {
-                                            // 오디오 비주얼라이저 색상
-                                            speakerSwitch = SpeakerSwitch.speakerOne
-                                            visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
-                                        } else {
-                                            // 오디오 비주얼라이저 색상
-                                            speakerSwitch = SpeakerSwitch.speakerTwo
-                                            visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
-                                        }
-                                    }
-                                }
-                        )
-                        // 화자전환 가이드
-                        .overlay(
-                            Group {
-                                if speakerSwitch == SpeakerSwitch.speakerOne {
-                                    // 내가 화자일때
-                                    VStack {
-                                        Spacer()
-                                            .frame(height: 480)
-                                        Image(systemName: "chevron.compact.up")
-                                            .resizable()
-                                            .frame(width: 34, height: 10)
-                                            .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
-                                            .padding(.bottom, 10)
-                                        Text("쓸어올려 상대로 전환")
-                                            .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
-                                    }
-                                } else {
-                                    // 상대가 화자일때
-                                    VStack{
-                                        Spacer()
-                                            .frame(height: 480)
-                                        Image(systemName: "chevron.compact.down")
-                                            .resizable()
-                                            .frame(width: 34, height: 10)
-                                            .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
-                                            .padding(.bottom, 10)
-                                        Text("쓸어내려 나로 전환")
-                                            .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
-                                    }
-                                }
+                )
+            // 화자전환 가이드
+                .overlay(alignment: .bottom) {
+                    Group {
+                        if speakerSwitch == SpeakerSwitch.speakerOne {
+                            // 내가 화자일때
+                            VStack {
+                                Image(systemName: "chevron.compact.up")
+                                    .resizable()
+                                    .frame(width: 34, height: 10)
+                                    .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
+                                    .padding(.bottom, 10)
+                                Text("쓸어올려 상대로 전환")
+                                    .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
                             }
-                                .font(.headline)
-                                .fontWeight(.bold)
-                        )
-                    
-                // 화자전환 영역과 오디오 비주얼라이저 사이 마진 Spacer
-                Spacer()
-                
-                // 오디오 비쥬얼라이저 뷰
-                AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording, isPaused: $isPaused, audioVisualizerColor: $visualColor)
-                    .padding()
-                    
-            } // 컨트롤영역 + 화자전환영역 + 오디오 비주얼라이저 VStack 닫기
-            .onAppear {
-                audioInputManager.prepare()
-            }
-            .onDisappear {
-                audioInputManager.stopRecording()
-            }
-        } // 배경영역 + 기능영역(컨트롤영역 + 화자전환영역 + 오디오 비주얼라이저) ZStack 닫기
+                        } else {
+                            // 상대가 화자일때
+                            VStack{
+                                Spacer()
+                                    .frame(height: 480)
+                                Image(systemName: "chevron.compact.down")
+                                    .resizable()
+                                    .frame(width: 34, height: 10)
+                                    .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
+                                    .padding(.bottom, 10)
+                                Text("쓸어내려 나로 전환")
+                                    .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
+                            }
+                        }
+                    }
+                    .padding(.bottom, 80)
+                    .font(.headline)
+                    .fontWeight(.bold)
+                }
+            
+            // 오디오 비쥬얼라이저 뷰
+            AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording, isPaused: $isPaused, audioVisualizerColor: $visualColor)
+        }
+        .frame(
+            maxWidth: .infinity,
+            maxHeight: .infinity
+        )// 컨트롤영역 + 화자전환영역 + 오디오 비주얼라이저 VStack 닫기
+        .background (
+            Color.black
+        )
+        .onAppear {
+            audioInputManager.prepare()
+        }
+        .onDisappear {
+            audioInputManager.stopRecording()
+        }
     } // body
 } // struct
 
 
 struct InterviewRecordingView_Previews: PreviewProvider {
     static var previews: some View {
-        InterviewRecordingView()
+            InterviewRecordingView()
     }
 }

--- a/Pressor/Pressor/Views/RecordViews/AudioVisualizerView.swift
+++ b/Pressor/Pressor/Views/RecordViews/AudioVisualizerView.swift
@@ -15,6 +15,8 @@ struct AudioVisualizerView: View {
     @Binding var isRecording: Bool
     // 일시정지 여부를 나타내는 바인딩 변수
     @Binding var isPaused: Bool
+    // 색을 나타내는 바인딩 변수
+    @Binding var audioVisualizerColor: Color
     // 각 막대의 높이를 저장하는 배열
     @State private var barHeights: [CGFloat] = Array(repeating: 0, count: 40)
     
@@ -25,7 +27,11 @@ struct AudioVisualizerView: View {
                     HStack(spacing: 3) {
                         // 각 막대를 생성, 높이와 애니메이션 적용.
                         ForEach(0..<barHeights.count, id: \.self) { index in
-                            BarView(height: barHeights[index] * weight(for: index), isRecording: isRecording)
+                            BarView(
+                                height: barHeights[index] * weight(for: index),
+                                isRecording: isRecording,
+                                audioVisualColor: audioVisualizerColor
+                            )
                                 .animation(.easeInOut(duration: 0.15), value: barHeights[index])
                         }
                     }
@@ -88,7 +94,7 @@ extension AudioVisualizerView {
         let samples = Array(UnsafeBufferPointer(start: buffer.floatChannelData?[0], count: Int(buffer.frameLength)))
         let sampleCount = samples.count
         let blockSize = sampleCount / barHeights.count
-        let maxHeight = UIScreen.main.bounds.height
+        let maxHeight = UIScreen.main.bounds.height / 3
 
         for i in 0..<barHeights.count {
             let start = i * blockSize
@@ -112,11 +118,12 @@ extension AudioVisualizerView {
 struct BarView: View {
     var height: CGFloat
     var isRecording: Bool
+    var audioVisualColor: Color
     
     var body: some View {
-        let safeHeight = max(min(height, CGFloat.greatestFiniteMagnitude), 2)
+        let safeHeight = max(min(height, CGFloat.greatestFiniteMagnitude), 3)
         RoundedRectangle(cornerRadius: 4)
-            .fill(isRecording ? Color.red : Color.black)
-            .frame(height: safeHeight)
+            .fill(audioVisualColor)
+            .frame(maxHeight: safeHeight)
     }
 }

--- a/Pressor/Pressor/Views/RecordViews/AudioVisualizerView.swift
+++ b/Pressor/Pressor/Views/RecordViews/AudioVisualizerView.swift
@@ -1,0 +1,121 @@
+//
+//  AudioVisualizerView.swift
+//  Pressor
+//
+//  Created by Ha Jong Myeong on 2023/05/02.
+//
+
+import SwiftUI
+import AVFoundation
+import Charts
+
+struct AudioVisualizerView: View {
+    @StateObject private var audioInputManager = AudioInputManager()
+    @State private var barHeights: [CGFloat] = Array(repeating: 0, count: 50)
+
+    var body: some View {
+        VStack {
+            HStack(spacing: 4) {
+                // 각 막대를 반복하여 표시
+                ForEach(0..<barHeights.count) { index in
+                    BarView(height: barHeights[index])
+                }
+            }
+
+//            Button(action: toggleRecording) {
+//                Text("Toggle Recording")
+//                    .padding()
+//                    .background(Color.blue)
+//                    .foregroundColor(.white)
+//                    .cornerRadius(10)
+//            }
+        }
+        .onAppear {
+            // 뷰가 나타날 때 녹음 시작
+            audioInputManager.startRecording { buffer in
+                DispatchQueue.main.async {
+                    self.updateBarHeights(with: buffer)
+                }
+            }
+        }
+    }
+
+//    private func toggleRecording() {
+//        if audioInputManager.audioEngine.isRunning {
+//            audioInputManager.stopRecording()
+//        } else {
+//            audioInputManager.startRecording { buffer in
+//                DispatchQueue.main.async {
+//                    self.updateBarHeights(with: buffer)
+//                }
+//            }
+//        }
+//    }
+
+    // 막대 높이 업데이트(에니베이션)
+    private func updateBarHeights(with buffer: AVAudioPCMBuffer) {
+        let samples = Array(UnsafeBufferPointer(start: buffer.floatChannelData?[0], count: Int(buffer.frameLength)))
+        let sampleCount = samples.count
+        let blockSize = sampleCount / barHeights.count
+
+        for i in 0..<barHeights.count {
+            let start = i * blockSize
+            let end = start + blockSize
+            let slice = samples[start..<end]
+
+            let rms = calculateRMS(for: Array(slice))
+            let normalizedHeight = CGFloat(min(max(0, rms), 1)) * UIScreen.main.bounds.height / 3
+            barHeights[i] = normalizedHeight
+        }
+    }
+
+    // RMS 계산
+    private func calculateRMS(for samples: [Float]) -> Float {
+        let sumOfSquares = samples.reduce(0) { $0 + $1 * $1 }
+        let rms = sqrt(sumOfSquares / Float(samples.count))
+        return rms
+    }
+
+}
+
+
+struct BarView: View {
+    var height: CGFloat
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(Color.black)
+            .frame(height: height)
+    }
+}
+
+class AudioInputManager: ObservableObject {
+    var audioEngine: AVAudioEngine
+    private var audioBufferHandler: ((AVAudioPCMBuffer) -> Void)?
+
+    init() {
+        audioEngine = AVAudioEngine()
+    }
+
+    // 녹음 시작
+    func startRecording(_ audioBufferHandler: @escaping (AVAudioPCMBuffer) -> Void) {
+        self.audioBufferHandler = audioBufferHandler
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            self.audioBufferHandler?(buffer)
+        }
+
+        do {
+            try audioEngine.start()
+        } catch {
+            print("Error starting audio engine: \(error)")
+        }
+    }
+
+    func stopRecording() {
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+    }
+}

--- a/Pressor/Pressor/Views/RecordViews/AudioVisualizerView.swift
+++ b/Pressor/Pressor/Views/RecordViews/AudioVisualizerView.swift
@@ -11,25 +11,23 @@ import Charts
 
 struct AudioVisualizerView: View {
     @StateObject private var audioInputManager = AudioInputManager()
-    @State private var barHeights: [CGFloat] = Array(repeating: 0, count: 50)
+    @State private var barHeights: [CGFloat] = Array(repeating: 0, count: 80)
 
     var body: some View {
         VStack {
-            HStack(spacing: 4) {
-                // 각 막대를 반복하여 표시
-                ForEach(0..<barHeights.count) { index in
-                    BarView(height: barHeights[index])
+            ZStack {
+                HStack {
+                    // 왼쪽 막대 그룹
+                    HStack(spacing: 2) {
+                        ForEach(0..<barHeights.count) { index in
+                            BarView(height: barHeights[index] * weight(for: index))
+                                .animation(.easeInOut(duration: 0.15), value: barHeights[index])
+                        }
+                    }
                 }
-            }
-
-//            Button(action: toggleRecording) {
-//                Text("Toggle Recording")
-//                    .padding()
-//                    .background(Color.blue)
-//                    .foregroundColor(.white)
-//                    .cornerRadius(10)
-//            }
-        }
+            }}
+        .frame(height: 80)
+        .background(.black)
         .onAppear {
             // 뷰가 나타날 때 녹음 시작
             audioInputManager.startRecording { buffer in
@@ -40,51 +38,59 @@ struct AudioVisualizerView: View {
         }
     }
 
-//    private func toggleRecording() {
-//        if audioInputManager.audioEngine.isRunning {
-//            audioInputManager.stopRecording()
-//        } else {
-//            audioInputManager.startRecording { buffer in
-//                DispatchQueue.main.async {
-//                    self.updateBarHeights(with: buffer)
-//                }
-//            }
-//        }
-//    }
-
-    // 막대 높이 업데이트(에니베이션)
+    // 인덱스에 따른 가중치 계산
+    private func weight(for index: Int) -> CGFloat {
+        let halfCount = CGFloat(barHeights.count / 2)
+        let relativeIndex = abs(CGFloat(index) - halfCount)
+        let weight = 1 - (2 * relativeIndex / halfCount)
+        return weight
+    }
+    
+    //    private func toggleRecording() {
+    //        if audioInputManager.audioEngine.isRunning {
+    //            audioInputManager.stopRecording()
+    //        } else {
+    //            audioInputManager.startRecording { buffer in
+    //                DispatchQueue.main.async {
+    //                    self.updateBarHeights(with: buffer)
+    //                }
+    //            }
+    //        }
+    //    }
+    
+    // 막대 높이 업데이트(에니메이션)
     private func updateBarHeights(with buffer: AVAudioPCMBuffer) {
         let samples = Array(UnsafeBufferPointer(start: buffer.floatChannelData?[0], count: Int(buffer.frameLength)))
         let sampleCount = samples.count
         let blockSize = sampleCount / barHeights.count
-
+        
         for i in 0..<barHeights.count {
             let start = i * blockSize
             let end = start + blockSize
             let slice = samples[start..<end]
-
+            
             let rms = calculateRMS(for: Array(slice))
             let normalizedHeight = CGFloat(min(max(0, rms), 1)) * UIScreen.main.bounds.height / 3
             barHeights[i] = normalizedHeight
         }
     }
-
+    
     // RMS 계산
     private func calculateRMS(for samples: [Float]) -> Float {
         let sumOfSquares = samples.reduce(0) { $0 + $1 * $1 }
         let rms = sqrt(sumOfSquares / Float(samples.count))
         return rms
     }
-
+    
 }
 
 
 struct BarView: View {
     var height: CGFloat
-
+    
     var body: some View {
         RoundedRectangle(cornerRadius: 4)
-            .fill(Color.black)
+            .fill(Color.white)
             .frame(height: height)
     }
 }
@@ -92,28 +98,28 @@ struct BarView: View {
 class AudioInputManager: ObservableObject {
     var audioEngine: AVAudioEngine
     private var audioBufferHandler: ((AVAudioPCMBuffer) -> Void)?
-
+    
     init() {
         audioEngine = AVAudioEngine()
     }
-
+    
     // 녹음 시작
     func startRecording(_ audioBufferHandler: @escaping (AVAudioPCMBuffer) -> Void) {
         self.audioBufferHandler = audioBufferHandler
         let inputNode = audioEngine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
-
+        
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
             self.audioBufferHandler?(buffer)
         }
-
+        
         do {
             try audioEngine.start()
         } catch {
             print("Error starting audio engine: \(error)")
         }
     }
-
+    
     func stopRecording() {
         audioEngine.inputNode.removeTap(onBus: 0)
         audioEngine.stop()


### PR DESCRIPTION
## 개요 및 관련 이슈
선행 작업: #8

## 작업 사항

- 대본 없을때 뷰만 구현됨
- 대본 있을때 뷰는 추후 구현 필요

- **InterviewRecordingView**
    - isPaused값을 false에서 true로 변경
    - 타이머 시간 포맷을 mm:ss로 변경해주는 formattedDuration함수 추가
    - 화면 회전 버튼 삭제 (화면 회전 기능 필요 없음)
    - 정지 및 일시정지 버튼을 상단으로 이동 (HStack 내부에서 Spacer을 이용해서 맛춘거라 다른 기기에서는 레이아웃이 틀어질 것)
    - 정지 버튼을 완료 버튼으로 로직 변경 (추후 @hsw1920 EndView 연결)
    - 화자 변경 로직을 탭에서 상하 스와이프로 로직 변경

- AudioVisualizerView
    - 녹음 중일 때 오디오비주얼라이저의 색상을 더 추가하기 위해 로직을 변경했습니다.