### PR TITLE
Feat/#24 implement add script modal view

### DIFF
--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -30,10 +30,11 @@
 		7EDEB0D72A011E0E00176D72 /* RecordBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0D62A011E0E00176D72 /* RecordBubble.swift */; };
 		7EDEB0D92A011E1500176D72 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0D82A011E1500176D72 /* Record.swift */; };
 		7EDEB0DB2A011E2A00176D72 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */; };
+		AC4F69E82A024ECD0035FC59 /* InterviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */; };
+		C918E6E02A09CC720074BAF0 /* AddScriptModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C918E6DF2A09CC720074BAF0 /* AddScriptModalView.swift */; };
 		C957BB9F2A027D05006649A8 /* InterviewRecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C957BB9E2A027D05006649A8 /* InterviewRecordingView.swift */; };
 		C957BBA12A028DDC006649A8 /* AudioInputVIewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C957BBA02A028DDC006649A8 /* AudioInputVIewModel.swift */; };
 		C9C7BC822A021F1F005E473B /* AudioVisualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */; };
-		AC4F69E82A024ECD0035FC59 /* InterviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,10 +63,11 @@
 		7EDEB0D62A011E0E00176D72 /* RecordBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBubble.swift; sourceTree = "<group>"; };
 		7EDEB0D82A011E1500176D72 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
+		AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewListView.swift; sourceTree = "<group>"; };
+		C918E6DF2A09CC720074BAF0 /* AddScriptModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddScriptModalView.swift; sourceTree = "<group>"; };
 		C957BB9E2A027D05006649A8 /* InterviewRecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewRecordingView.swift; sourceTree = "<group>"; };
 		C957BBA02A028DDC006649A8 /* AudioInputVIewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputVIewModel.swift; sourceTree = "<group>"; };
 		C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVisualizerView.swift; sourceTree = "<group>"; };
-		AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewListView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,6 +197,7 @@
 				7EDEB0D02A011DD100176D72 /* MainRecordView.swift */,
 				7EDEB0D22A011DE800176D72 /* AddRecordScriptModalView.swift */,
 				C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */,
+				C918E6DF2A09CC720074BAF0 /* AddScriptModalView.swift */,
 			);
 			path = RecordViews;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 				7EC865EA2A05044C0041B31A /* View+DismissKeyboard.swift in Sources */,
 				7EDEB0BF2A011B4B00176D72 /* ContentView.swift in Sources */,
 				608D9D7F2A022F5E001E8E3C /* MainTestView.swift in Sources */,
+				C918E6E02A09CC720074BAF0 /* AddScriptModalView.swift in Sources */,
 				608D9D6C2A013AF0001E8E3C /* InterviewRecordingTestView.swift in Sources */,
 				7EDEB0D12A011DD100176D72 /* MainRecordView.swift in Sources */,
 				7EDEB0D32A011DE800176D72 /* AddRecordScriptModalView.swift in Sources */,
@@ -438,14 +442,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pressor/Preview Content\"";
-				DEVELOPMENT_TEAM = CV4G9J35Y5;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				DEVELOPMENT_TEAM = 3NP4Z3WZ94;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pressor/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -475,14 +476,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pressor/Preview Content\"";
-				DEVELOPMENT_TEAM = CV4G9J35Y5;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				DEVELOPMENT_TEAM = 3NP4Z3WZ94;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pressor/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
+++ b/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
@@ -46,13 +46,14 @@ struct AddScriptModalView: View {
         ZStack(alignment: .topLeading) {
             TextEditor(text: $bodyText)
                 .frame(height: 270)
+                .padding(.leading, -4)
             
             if bodyText.isEmpty {
             // 본문이 비어있을 때만 "본문" 텍스트 표시
                 Text("본문")
                     .foregroundColor(.gray.opacity(0.5))
                     .padding(.top, 8)
-                    .padding(.leading, 4)
+                    .padding(.leading, -2)
             }
         }
     }

--- a/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
+++ b/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
@@ -1,0 +1,20 @@
+//
+//  AddScriptModalView.swift
+//  Pressor
+//
+//  Created by Ha Jong Myeong on 2023/05/09.
+//
+
+import SwiftUI
+
+struct AddScriptModalView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct AddScriptModalView_Previews: PreviewProvider {
+    static var previews: some View {
+        AddScriptModalView()
+    }
+}

--- a/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
+++ b/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
@@ -1,20 +1,88 @@
 //
-//  AddScriptModalView.swift
-//  Pressor
+// AddScriptModalView.swift
+// Pressor
 //
-//  Created by Ha Jong Myeong on 2023/05/09.
+// Created by Ha Jong Myeong on 2023/05/09.
 //
 
 import SwiftUI
 
 struct AddScriptModalView: View {
+    // 화면 전환을 관리하는 presentationMode를 사용하여 모달 창을 닫을 수 있도록 하는 변수
+    @Environment(\.presentationMode) private var presentationMode
+    
+    // 외부에서 전달된 scriptAdded를 바인딩하여 완료 버튼을 눌렀을 때 업데이트
+    @Binding var scriptAdded: Bool
+    
+    @State private var title = ""
+    @State private var bodyText = ""
+    
+    // 메인 뷰
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationView {
+            Form {
+                inputSection
+            }
+            .navigationBarTitle("대본", displayMode: .inline)
+            .navigationBarItems(leading: cancelButton, trailing: doneButton)
+        }
+    }
+    
+    // 입력 섹션
+    private var inputSection: some View {
+        Section {
+            titleTextField
+            bodyTextEditor
+        }
+    }
+    
+    // 제목 입력 필드
+    private var titleTextField: some View {
+        TextField("제목", text: $title)
+    }
+    
+    // 본문 입력 에디터
+    private var bodyTextEditor: some View {
+        ZStack(alignment: .topLeading) {
+            TextEditor(text: $bodyText)
+                .frame(height: 270)
+            
+            if bodyText.isEmpty {
+            // 본문이 비어있을 때만 "본문" 텍스트 표시
+                Text("본문")
+                    .foregroundColor(.gray.opacity(0.5))
+                    .padding(.top, 8)
+                    .padding(.leading, 4)
+            }
+        }
+    }
+    
+    // 취소 버튼
+    private var cancelButton: some View {
+        Button("취소") {
+            presentationMode.wrappedValue.dismiss()
+        }
+        .foregroundColor(.red)
+    }
+    
+    // 완료 버튼
+    private var doneButton: some View {
+        Button("완료") {
+            if isInputValid() {
+                // 제목과 본문을 입력한 경우, scriptAdded를 true로 설정하고 모달 창 종료
+                scriptAdded = true
+                presentationMode.wrappedValue.dismiss()
+            }
+        }
+        // 제목과 본문을 입력하지 않은 경우, "완료" 버튼 비활성화
+        .foregroundColor(isInputValid() ? .red : .gray)
+        .disabled(!isInputValid())
     }
 }
 
-struct AddScriptModalView_Previews: PreviewProvider {
-    static var previews: some View {
-        AddScriptModalView()
+private extension AddScriptModalView {
+    // 제목과 본문을 입력했는지 확인하는 함수
+    func isInputValid() -> Bool {
+        return !title.isEmpty && !bodyText.isEmpty
     }
 }

--- a/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
+++ b/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
@@ -9,9 +9,10 @@ import SwiftUI
 
 struct MainRecordView: View {
     
-    @State var isTapped: Bool = false
     @State var isSheetShowing: Bool = false
     @State var isShowingAlert = false
+    @State var showModal = false
+    @State var scriptAdded: Bool = false
     @State var count = 3
     
     var body: some View {
@@ -55,86 +56,70 @@ struct MainRecordView: View {
                                 .padding(.bottom, 67)
                             }
                         }
-                        
                     }
                     VStack {
                         Button(action: {
-                            self.isTapped.toggle()
-                            self.isSheetShowing = true
-                        }) {
-                            if self.isTapped {
-                                VStack {
-                                    Image(systemName: "note.text")
-                                        .resizable()
-                                        .frame(width: 35, height: 33)
-                                        .foregroundColor(Color.accentColor)
-                                    Text("대본편집")
-                                        .foregroundColor(Color.accentColor)
-                                }
-                                .confirmationDialog("타이틀", isPresented: $isSheetShowing) {
-                                    Button("대본 삭제", role: .destructive) {
-                                        self.isShowingAlert = true
-                                    }
-                                    .alert(isPresented: $isShowingAlert) {
-                                        Alert(title: Text("대본 삭제"),
-                                              message: Text("대본을 정말 삭제하시겠습니까?"),
-                                              dismissButton: .default(Text("OK")))
-                                    }
-                                    Button("대본 수정", role: .destructive) {
-                                        
-                                    }
-                                    Button("취소", role: .cancel) {
-                                        
-                                    }
-                                }
+                            if scriptAdded {
+                                self.isSheetShowing = true
+                                scriptAdded = true
                             } else {
-                                VStack {
+                                showModal.toggle()
+                                scriptAdded = false
+                            }
+                        }) {
+                            VStack {
+                                if scriptAdded {
+                                    VStack{
+                                        Image(systemName: "note.text")
+                                            .resizable()
+                                            .frame(width: 35, height: 33)
+                                            .foregroundColor(Color.accentColor)
+                                        Text("대본편집")
+                                            .foregroundColor(Color.accentColor)
+                                    }.confirmationDialog("타이틀", isPresented: $isSheetShowing) {
+                                        Button("대본 삭제", role: .destructive) {
+                                            self.isShowingAlert = true
+                                        }
+                                        .alert(isPresented: $isShowingAlert) {
+                                            Alert(title: Text("Alert Title"), message: Text("Alert Message"), dismissButton: .default(Text("OK")))}
+                                        Button("대본 수정", role: .destructive) {
+                                            
+                                        }
+                                        Button("취소", role: .cancel) {
+                                            
+                                        }
+                                    }
+                                } else {
                                     Image(systemName: "note.text.badge.plus")
                                         .resizable()
                                         .frame(width: 35, height: 33)
                                         .foregroundColor(Color.accentColor)
-                                    Text("대본추가")
+                                    Text("대본 추가")
                                         .foregroundColor(Color.accentColor)
-                                }
-                                .confirmationDialog("타이틀", isPresented: $isSheetShowing) {
-                                    Button("대본 삭제", role: .destructive) {
-                                        self.isShowingAlert = true
-                                    }
-                                    .alert(isPresented: $isShowingAlert) {
-                                        Alert(title: Text("Alert Title"), message: Text("Alert Message"), dismissButton: .default(Text("OK")))}
-                                    Button("대본 수정", role: .destructive) {
-                                        
-                                    }
-                                    Button("취소", role: .cancel) {
-                                        
-                                    }
                                 }
                             }
                         }
                     }
+                    .navigationBarTitle("Pressor")
+                    .navigationBarItems(trailing: NavigationLink(destination: AddRecordScriptModalView()) {
+                        Image(systemName: "gearshape.fill")})
+                    .foregroundColor(Color(red: 209/255, green: 209/255, blue: 214/255))
                 }
-                .navigationBarTitle("Pressor")
-                .navigationBarItems(trailing: NavigationLink(destination: AddRecordScriptModalView()) {
-                    Image(systemName: "gearshape.fill")})
-                .foregroundColor(Color(red: 209/255, green: 209/255, blue: 214/255))
-            }
-            .tabItem {
-                Image(systemName: "mic.circle.fill")
-                Text("녹음")
-            }
-            
-            InterviewListView()
                 .tabItem {
-                    Image(systemName: "doc.plaintext")
-                    Text("인터뷰")
+                    Image(systemName: "mic.circle.fill")
+                    Text("녹음")
                 }
-        }
-        .accentColor(.red)
-    }
-    
-    struct MainRecordView_Previews: PreviewProvider {
-        static var previews: some View {
-            MainRecordView()
+                
+                InterviewListView()
+                    .tabItem {
+                        Image(systemName: "doc.plaintext")
+                        Text("인터뷰")
+                    }
+            }            .sheet(isPresented: $showModal, onDismiss: {
+            }) {
+                AddScriptModalView(scriptAdded: $scriptAdded)
+            }
+            .accentColor(.red)
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
- AddScriptModalView 기본 레이아웃 구성
- MainRecordView 연동(대본 완성 여부에 따른 대본 편집, 추가 전환)

- 대본 입력 화면은 모달 뷰 형태로 나타나며 상단의 "취소" 버튼을 통해 뷰를 닫을 수 있음.
- "완료" 버튼은 제목과 본문 텍스트 필드에 모두 내용이 있을 때만 활성화되어 유효한 입력을 확인한 후 진행.
- "완료" 버튼을 누르면 scriptAdded 바인딩이 true로 설정되어 새 스크립트가 성공적으로 추가되었음을 나타냄.

## 작업 사항
[#](https://github.com/DeveloperAcademy-POSTECH/MC2_2thCo.6thPlatoon/commit/c4a82e794595f65fc518fdc7be79c25262e0bf5b)
- 새로운 SwiftUI View인 AddScriptModalView를 생성.
- 모달 뷰를 닫기 위해 presentationMode 환경 바인딩을 추가.
- 새 스크립트가 추가될 때 부모 뷰를 업데이트하기 위해 scriptAdded 바인딩을 생성.
- 사용자 입력을 처리하기 위해 title 및 bodyText 상태 변수를 추가.
- 제목 TextField 및 본문 TextEditor를 포함한 입력 섹션과 같은 UI 구성 요소를 구현.
