### PR TITLE
[Feat/#31] implement color extension 색상 추가

### DIFF
--- a/Pressor/Pressor/Resources/Extensions/Color+.swift
+++ b/Pressor/Pressor/Resources/Extensions/Color+.swift
@@ -33,4 +33,28 @@ extension Color {
     static var PressorRed: Self {
         .init(hex: "#FF3B30")
     }
+    static var PressorBlue_Light: Self {
+        .init(hex: "B1F2F0")
+    }
+    static var PressorBlue: Self {
+        .init(hex: "00EADF")
+    }
+    static var PressorOrange_Light: Self {
+        .init(hex: "FFDB99")
+    }
+    static var PressorOrange: Self {
+        .init(hex: "FFA600")
+    }
+    static var BackgroundGray_Dark: Self {
+        .init(hex: "2C2C2E")
+    }
+    static var BackgroundGray_Light: Self {
+        .init(hex: "F2F2F7")
+    }
+    static var SymbolGray: Self {
+        .init(hex: "D1D1D6")
+    }
+    static var DisabledGary: Self {
+        .init(hex: "999999")
+    }
 }

--- a/Pressor/Pressor/Resources/Extensions/Color+.swift
+++ b/Pressor/Pressor/Resources/Extensions/Color+.swift
@@ -33,6 +33,9 @@ extension Color {
     static var PressorRed: Self {
         .init(hex: "#FF3B30")
     }
+    static var PressorRed_Dark: Self {
+        .init(hex: "4D120F")
+    }
     static var PressorBlue_Light: Self {
         .init(hex: "B1F2F0")
     }


### PR DESCRIPTION
## 개요 및 관련 이슈

- 앱 내에서 사용할 커스텀 색상을 RGB에서 Hex로 교체하기 위한 static을 extension에 추가합니다.

## 작업 사항

- 앱 내에서 사용할 커스텀 색상을 Color+.swift / extension에 static Hex로 추가했습니다.