### PR TITLE
Feat/#28 implement interview script modeling script crud

### DIFF
--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -32,6 +32,10 @@
 		7EDEB0DB2A011E2A00176D72 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */; };
 		AC4F69E82A024ECD0035FC59 /* InterviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */; };
 		C918E6E02A09CC720074BAF0 /* AddScriptModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C918E6DF2A09CC720074BAF0 /* AddScriptModalView.swift */; };
+		C91E4D312A0A545800E5F983 /* InterviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91E4D302A0A545800E5F983 /* InterviewViewModel.swift */; };
+		C91E4D332A0A8CAE00E5F983 /* InterviewScriptTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91E4D322A0A8CAE00E5F983 /* InterviewScriptTestView.swift */; };
+		C91E4D392A0A979F00E5F983 /* EditInterviewScriptTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91E4D382A0A979F00E5F983 /* EditInterviewScriptTestView.swift */; };
+		C91E4D3B2A0B746300E5F983 /* InterviewScriptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91E4D3A2A0B746300E5F983 /* InterviewScriptModel.swift */; };
 		C957BB9F2A027D05006649A8 /* InterviewRecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C957BB9E2A027D05006649A8 /* InterviewRecordingView.swift */; };
 		C957BBA12A028DDC006649A8 /* AudioInputVIewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C957BBA02A028DDC006649A8 /* AudioInputVIewModel.swift */; };
 		C9C7BC822A021F1F005E473B /* AudioVisualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */; };
@@ -65,6 +69,10 @@
 		7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
 		AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewListView.swift; sourceTree = "<group>"; };
 		C918E6DF2A09CC720074BAF0 /* AddScriptModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddScriptModalView.swift; sourceTree = "<group>"; };
+		C91E4D302A0A545800E5F983 /* InterviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewViewModel.swift; sourceTree = "<group>"; };
+		C91E4D322A0A8CAE00E5F983 /* InterviewScriptTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewScriptTestView.swift; sourceTree = "<group>"; };
+		C91E4D382A0A979F00E5F983 /* EditInterviewScriptTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditInterviewScriptTestView.swift; sourceTree = "<group>"; };
+		C91E4D3A2A0B746300E5F983 /* InterviewScriptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewScriptModel.swift; sourceTree = "<group>"; };
 		C957BB9E2A027D05006649A8 /* InterviewRecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewRecordingView.swift; sourceTree = "<group>"; };
 		C957BBA02A028DDC006649A8 /* AudioInputVIewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputVIewModel.swift; sourceTree = "<group>"; };
 		C9C7BC812A021F1F005E473B /* AudioVisualizerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVisualizerView.swift; sourceTree = "<group>"; };
@@ -88,6 +96,8 @@
 				608D9D7C2A01F673001E8E3C /* InterviewDetailTestView.swift */,
 				6072D0E62A0542E6005583FC /* InterviewRecordingEndTestView.swift */,
 				608D9D7E2A022F5E001E8E3C /* MainTestView.swift */,
+				C91E4D322A0A8CAE00E5F983 /* InterviewScriptTestView.swift */,
+				C91E4D382A0A979F00E5F983 /* EditInterviewScriptTestView.swift */,
 			);
 			path = TestViews;
 			sourceTree = "<group>";
@@ -167,6 +177,7 @@
 				7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */,
 				C957BBA02A028DDC006649A8 /* AudioInputVIewModel.swift */,
 				608D9D6F2A014BEE001E8E3C /* VoiceViewModel.swift */,
+				C91E4D302A0A545800E5F983 /* InterviewViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -177,6 +188,7 @@
 				7EDEB0D82A011E1500176D72 /* Record.swift */,
 				6072D0E42A053E93005583FC /* Interview.swift */,
 				6072D0F32A05E513005583FC /* InterviewDetail.swift */,
+				C91E4D3A2A0B746300E5F983 /* InterviewScriptModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -303,17 +315,21 @@
 				AC4F69E82A024ECD0035FC59 /* InterviewListView.swift in Sources */,
 				7EDEB0DB2A011E2A00176D72 /* RecordViewModel.swift in Sources */,
 				7E6E395D2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift in Sources */,
+				C91E4D392A0A979F00E5F983 /* EditInterviewScriptTestView.swift in Sources */,
 				7EDEB0BD2A011B4B00176D72 /* PressorApp.swift in Sources */,
 				7EDEB0D92A011E1500176D72 /* Record.swift in Sources */,
+				C91E4D332A0A8CAE00E5F983 /* InterviewScriptTestView.swift in Sources */,
 				7E6E395F2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift in Sources */,
 				7EC865EC2A050A2C0041B31A /* Color+.swift in Sources */,
 				7EDEB0D72A011E0E00176D72 /* RecordBubble.swift in Sources */,
 				C957BB9F2A027D05006649A8 /* InterviewRecordingView.swift in Sources */,
 				608D9D702A014BEE001E8E3C /* VoiceViewModel.swift in Sources */,
 				608D9D7D2A01F673001E8E3C /* InterviewDetailTestView.swift in Sources */,
+				C91E4D312A0A545800E5F983 /* InterviewViewModel.swift in Sources */,
 				7EDEB0D52A011DF600176D72 /* MainInterviewList.swift in Sources */,
 				6072D0E52A053E93005583FC /* Interview.swift in Sources */,
 				601CCC4D2A08D53F005B02C7 /* Date+.swift in Sources */,
+				C91E4D3B2A0B746300E5F983 /* InterviewScriptModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pressor/Pressor/Models/InterviewScriptModel.swift
+++ b/Pressor/Pressor/Models/InterviewScriptModel.swift
@@ -1,0 +1,12 @@
+//
+//  InterviewScriptModel.swift
+//  Pressor
+//
+//  Created by Ha Jong Myeong on 2023/05/10.
+//
+
+import Foundation
+
+struct InterviewScriptModel {
+    var interviewScript: [(title: String, content: String)]
+}

--- a/Pressor/Pressor/ViewModels/InterviewViewModel.swift
+++ b/Pressor/Pressor/ViewModels/InterviewViewModel.swift
@@ -1,0 +1,41 @@
+//  InterviewViewModel.swift
+//  Pressor
+//
+//  Created by Ha Jong Myeong on 2023/05/05.
+//
+
+import Foundation
+
+class InterviewViewModel: ObservableObject {
+    // 인터뷰 목록
+    @Published var interviewScriptModel: InterviewScriptModel
+    
+    // Default initializer
+    init() {
+        self.interviewScriptModel = InterviewScriptModel(interviewScript: [])
+    }
+    
+    // 대본 생성
+    func createScript(title: String, content: String) {
+        // 대본 추가
+        interviewScriptModel.interviewScript.append((title: title, content: content))
+    }
+    
+    // 대본 읽기
+    func getScripts() -> [(title: String, content: String)] {
+        // 대본 목록 반환
+        return interviewScriptModel.interviewScript
+    }
+    
+    // 대본 수정
+    func updateScript(title: String, content: String, atIndex index: Int) {
+        // 대본 수정
+        interviewScriptModel.interviewScript[index] = (title: title, content: content)
+    }
+    
+    // 대본 삭제
+    func deleteScript(atIndex index: Int) {
+        // 대본 삭제
+        interviewScriptModel.interviewScript.remove(at: index)
+    }
+}

--- a/Pressor/Pressor/Views/TestViews/EditInterviewScriptTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/EditInterviewScriptTestView.swift
@@ -1,0 +1,46 @@
+//
+//  EditInterviewScriptTestView.swift
+//  Pressor
+//
+//  Created by Ha Jong Myeong on 2023/05/10.
+//
+
+import SwiftUI
+
+struct EditInterviewScriptTestView: View {
+    @ObservedObject var viewModel: InterviewViewModel
+    @Environment(\.presentationMode) var presentationMode
+    @State private var title: String
+    @State private var content: String
+    let index: Int
+    
+    init(viewModel: InterviewViewModel, index: Int, updatedTitle: String, updatedContent: String) {
+        self.viewModel = viewModel
+        self._title = State(wrappedValue: updatedTitle)
+        self._content = State(wrappedValue: updatedContent)
+        self.index = index
+    }
+    
+    var body: some View {
+        VStack {
+            TextField("Enter title", text: $title)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            TextField("Enter content", text: $content)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            Button(action: {
+                viewModel.updateScript(title: title, content: content, atIndex: index)
+                        presentationMode.wrappedValue.dismiss()
+            }) {
+                Text("Update Interview Script")
+                    .bold()
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(Color.green)
+                    .cornerRadius(8)
+            }
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("Edit Interview Script")
+    }
+}

--- a/Pressor/Pressor/Views/TestViews/InterviewScriptTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/InterviewScriptTestView.swift
@@ -1,0 +1,66 @@
+// ScriptTestView.swift
+// Pressor
+//
+// Created by Ha Jong Myeong on 2023/05/09.
+//
+
+import SwiftUI
+
+struct InterviewScriptTestView: View {
+    @StateObject var viewModel: InterviewViewModel
+    @State private var newTitle = ""
+    @State private var newContent = ""
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                List {
+                    ForEach(viewModel.interviewScriptModel.interviewScript.indices, id: \.self) { index in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(viewModel.interviewScriptModel.interviewScript[index].title)
+                                .font(.headline)
+                            Text(viewModel.interviewScriptModel.interviewScript[index].content)
+                        }
+                        .onTapGesture {
+                            editInterviewScriptIndex = index
+                            showEditInterviewScriptView.toggle()
+                        }
+                    }
+                    .onDelete(perform: deleteInterviewScript)
+                }
+                
+                VStack(spacing: 12) {
+                    TextField("Enter title", text: $newTitle)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    TextField("Enter content", text: $newContent)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    Button(action: {
+                        viewModel.createScript(title: newTitle, content: newContent)
+                        newTitle = ""
+                        newContent = ""
+                    }) {
+                        Text("Add Interview Script")
+                            .bold()
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color.blue)
+                            .cornerRadius(8)
+                    }
+                }
+                .padding()
+                
+            }
+            .navigationTitle("Interview Scripts")
+            .sheet(isPresented: $showEditInterviewScriptView) {
+                EditInterviewScriptTestView(viewModel: viewModel, index: editInterviewScriptIndex, updatedTitle: viewModel.interviewScriptModel.interviewScript[editInterviewScriptIndex].title, updatedContent: viewModel.interviewScriptModel.interviewScript[editInterviewScriptIndex].content)
+            }
+        }
+    }
+    @State private var showEditInterviewScriptView = false
+    @State private var editInterviewScriptIndex = 0
+    private func deleteInterviewScript(at offsets: IndexSet) {
+        offsets.forEach { index in
+            viewModel.deleteScript(atIndex: index)
+        }
+    }
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
- 대본 CRUD를 위한 model, viewModel 생성.
- CRUD 테스트를 위한 Test View 구현 및 동작 테스트 완료.(InterviewScriptTestView 및 EditInterviewScriptTestView)

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
-  Script 모델 구성: 각 대본에는 제목(title)과 내용(content)이 포함(Models>interview)
-  InterviewViewModel 구현: Script 모델에 대한 CRUD 기능 추가
 -  대본 생성(createScript): 인터뷰에 대한 새로운 대본 추가
 -  대본 읽기(getScripts): 인터뷰에 대한 모든 대본 목록 반환
 -  대본 수정(updateScript): 인터뷰에 대한 특정 대본 수정
 -  대본 삭제(deleteScript): 인터뷰에 대한 특정 대본 삭제
 -  CRUD 테스트 뷰 생성, 해당 뷰를 통해 CRUD 확인 후 현 테스크 종료.

## 주요 로직(Optional)
```swift
struct InterviewScriptModel {
    var interviewScript: [(title: String, content: String)]
}
```
```swift
class InterviewViewModel: ObservableObject {
    // 인터뷰 목록
    @Published var interviewScriptModel: InterviewScriptModel
    
    // Default initializer
    init() {
        self.interviewScriptModel = InterviewScriptModel(interviewScript: [])
    }
    
    // 대본 생성
    func createScript(title: String, content: String) {
        // 대본 추가
        interviewScriptModel.interviewScript.append((title: title, content: content))
    }
    
    // 대본 읽기
    func getScripts() -> [(title: String, content: String)] {
        // 대본 목록 반환
        return interviewScriptModel.interviewScript
    }
    
    // 대본 수정
    func updateScript(title: String, content: String, atIndex index: Int) {
        // 대본 수정
        interviewScriptModel.interviewScript[index] = (title: title, content: content)
    }
    
    // 대본 삭제
    func deleteScript(atIndex index: Int) {
        // 대본 삭제
        interviewScriptModel.interviewScript.remove(at: index)
    }
}
```
## CRUD 테스트 결과 ✅

![7l7di9](https://github.com/DeveloperAcademy-POSTECH/MC2_2thCo.6thPlatoon/assets/36729917/9dd20db0-d514-4724-9683-d6088b85a3db)
