### PR TITLE
Feat/#42 merge test views

### DIFF
--- a/Pressor/Pressor/ViewModels/VoiceViewModel.swift
+++ b/Pressor/Pressor/ViewModels/VoiceViewModel.swift
@@ -62,6 +62,10 @@ class VoiceViewModel : NSObject, ObservableObject , AVAudioPlayerDelegate{
         
         self.interview = interview
         self.interviewPath = directoryPath
+        
+        // vm의 recording과 STT배열 초기화
+        self.recordings.removeAll()
+        self.transcripts.removeAll()
     }
     
     public func setInterviewDetail(interviewDetail: InterviewDetail) {

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -167,8 +167,6 @@ struct InterviewRecordingView: View {
                     // 완료 버튼 로직
                     NavigationLink(
                         destination: InterviewRecordingEndTestView(vm: vm)
-                            .navigationTitle("인터뷰 정보")
-                            .navigationBarTitleDisplayMode(.inline)
                             .onTapGesture {
                                 // 완료버튼 누를 때 interview 인스턴스를 업데이트
                                 vm.interview.recordSTT = vm.transcripts
@@ -187,6 +185,8 @@ struct InterviewRecordingView: View {
                                 )
                         } //label
                     ) // NavigationLink
+                    .navigationTitle("뒤로")
+                    .navigationBarHidden(true)
                     .disabled(isRecording)
                 } // HStack
                 

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 
 struct InterviewRecordingView: View {
+    @ObservedObject var vm: VoiceViewModel
+    
+    @State private var isShowingList = false
+    @State var transcriptIndex: Int = 0
     @StateObject private var audioInputManager = AudioInputViewModel()
     @State private var isRecording = false
     @State private var isPaused = true
@@ -92,6 +96,7 @@ struct InterviewRecordingView: View {
                             } else {
                                 visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
                             }
+                            vm.startRecording()
                         } else {
                             // 일시정지일때 -> 타이머 정지 및 오디오 비주얼라이저 끔
                             audioInputManager.stopRecording()
@@ -99,6 +104,13 @@ struct InterviewRecordingView: View {
                             stopTimer()
                             // 오디오 비주얼라이저 회색으로 비활성화 표시
                             visualColor = Color.gray
+                            
+                            // 일단 먼저 녹음중지하고 기록함
+                            vm.stopRecording(
+                                index: self.transcriptIndex,
+                                recoder: vm.recoderType
+                            )
+                            self.transcriptIndex += 1
                         }
                     }) {
                         // 일시정지 및 재생 버튼 UI
@@ -133,21 +145,36 @@ struct InterviewRecordingView: View {
                         x: UIScreen.main.bounds.width / 6.15,
                         y: UIScreen.main.bounds.height * 0.02
                     )
+                    .onAppear {
+                        vm.recoderType = Recorder.interviewer
+                        vm.startRecording()
+                        
+                        isRecording = true
+                        // 녹음 중일때 -> 녹음 시작 및 타이머 시작
+                        isPaused = false
+                        audioInputManager.startRecording { buffer in
+                            DispatchQueue.main.async {}
+                        }
+                        startTimer()
+                        // 녹음 중일때 or 일시정지일 떄 오디오 비주얼라이저 색상 변경
+                        if speakerSwitch == SpeakerSwitch.speakerOne {
+                            visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
+                        } else {
+                            visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
+                        }
+                    }
                     
                     // 완료 버튼 로직
                     NavigationLink(
-                        destination: InterviewRecordingEndTestView(vm: VoiceViewModel())
+                        destination: InterviewRecordingEndTestView(vm: vm)
                             .navigationTitle("인터뷰 정보")
                             .navigationBarTitleDisplayMode(.inline)
-                            .toolbar {
-                                ToolbarItem(placement: .navigationBarTrailing) {
-                                    Button(action: {
-                                    }, label: {
-                                        Text("완료")
-                                            .foregroundColor(Color.gray)
-                                    })
-                                }
-                            }, // toolbar
+                            .onTapGesture {
+                                // 완료버튼 누를 때 interview 인스턴스를 업데이트
+                                vm.interview.recordSTT = vm.transcripts
+                                vm.interview.records = vm.recordings
+                                vm.interview.details.playTime = formattedDuration(duration)
+                            },
                         label: {
                             Text("완료")
                                 .font(.headline)
@@ -174,20 +201,47 @@ struct InterviewRecordingView: View {
                 // 화자전환 제스처
                     .gesture(
                         DragGesture(minimumDistance: 100, coordinateSpace: .local)
-                            .onChanged { value in
-                                let isDraggingDownward = value.translation.height > 100
+                            
+                            .onEnded { value in
+                                let isDraggingDownward = (value.translation.height > 100 && speakerSwitch == SpeakerSwitch.speakerTwo) || (value.translation.height < -100 && speakerSwitch == SpeakerSwitch.speakerOne)
                                 withAnimation() {
                                     if isDraggingDownward {
                                         // 오디오 비주얼라이저 색상
-                                        speakerSwitch = SpeakerSwitch.speakerOne
-                                        visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
-                                    } else {
-                                        // 오디오 비주얼라이저 색상
-                                        speakerSwitch = SpeakerSwitch.speakerTwo
-                                        visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
+                                        if speakerSwitch == SpeakerSwitch.speakerOne {
+                                            speakerSwitch = SpeakerSwitch.speakerTwo
+                                            visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
+                                        } else {
+                                            speakerSwitch = SpeakerSwitch.speakerOne
+                                            visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
+                                        }
+                                        
+                                        if vm.isRecording {
+                                            // 화자바꾸지 않고 기록함
+                                            vm.stopRecording(
+                                                index: self.transcriptIndex,
+                                                recoder: vm.recoderType
+                                            )
+                                            self.transcriptIndex += 1
+                                            // 화자를 바꾸기
+                                            if vm.recoderType == Recorder.interviewer { // 인터뷰어일때
+                                                vm.recoderType = Recorder.interviewee // 화자 바꾸고
+                                            } else { // 인터뷰이일때
+                                                vm.recoderType = Recorder.interviewer
+                                            }
+                                            vm.startRecording()
+                                        } else {
+                                            // 화자를 바꾸기
+                                            if vm.recoderType == Recorder.interviewer { // 인터뷰어일때
+                                                vm.recoderType = Recorder.interviewee // 화자 바꾸고
+                                            } else { // 인터뷰이일때
+                                                vm.recoderType = Recorder.interviewer
+                                            }
+                                        }
                                     }
                                 }
+                                
                             }
+                            
                     )
                 // 화자전환 가이드
                     .overlay(alignment: .bottom) {
@@ -246,6 +300,6 @@ struct InterviewRecordingView: View {
 
 struct InterviewRecordingView_Previews: PreviewProvider {
     static var previews: some View {
-        InterviewRecordingView(isShownInterviewRecordingView: .constant(false))
+        InterviewRecordingView(vm: VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [])),isShownInterviewRecordingView: .constant(false))
     }
 }

--- a/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
+++ b/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MainRecordView: View {
     
+    @ObservedObject var vm: VoiceViewModel = VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: []))
     @State var isSheetShowing: Bool = false
     @State var isShowingAlert = false
     @State var showModal = false
@@ -53,25 +54,17 @@ struct MainRecordView: View {
                                     })
                                     
                                 }
-                                
-//                                count = 3
-//                                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-//                                    count = 2
-//                                }
-//                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-//                                    count = 1
-//                                }
-                                //                                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                                //                                    count = 0
-                                //                                    self.isShownInterviewRecordingView.toggle()
-                                //                                }
                             } label: {
                                 Image("mic_button")
                                     .padding(.bottom, 40)
                             }
                             .fullScreenCover(isPresented: $isShownInterviewRecordingView) {
-                                InterviewRecordingView(isShownInterviewRecordingView: $isShownInterviewRecordingView)
+                                InterviewRecordingView(vm: vm, isShownInterviewRecordingView: $isShownInterviewRecordingView)
                             }
+                            .simultaneousGesture(TapGesture().onEnded{
+                                vm.initInterview()
+                                print(vm.interview)
+                            })
                         }
                         VStack {
                             Button(action: {
@@ -146,6 +139,7 @@ struct MainRecordView: View {
                                     isTimerCounting.toggle()
                                     timerCount?.invalidate()
                                     countSec = 0
+                                    // TODO: 녹음을 취소하므로 path에서 해당하는 디렉토리 지우기
                                 }
                             Text("\(countSec)")
                                 .font(.system(size: 50, weight: .bold))

--- a/Pressor/Pressor/Views/TestViews/InterviewDetailTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/InterviewDetailTestView.swift
@@ -15,7 +15,7 @@ struct InterviewDetailTestView: View {
         NavigationView {
             VStack {
                 ScrollView(showsIndicators: false){
-                    ForEach(vm.recordings, id: \.id) { recording in
+                    ForEach(vm.interview.records, id: \.id) { recording in
                         VStack{
                             HStack{
 

--- a/Pressor/Pressor/Views/TestViews/InterviewRecordingEndTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/InterviewRecordingEndTestView.swift
@@ -13,10 +13,10 @@ struct InterviewRecordingEndTestView: View {
     @State private var isValid: Bool = false
     
     var body: some View {
-//        NavigationView {
             Form {
                 Section {
                     TextField("새로운 인터뷰", text: $vm.interview.details.interviewTitle)
+                        .foregroundColor(.black)
                 } header: {
                     Text("인터뷰 제목")
                 }
@@ -24,6 +24,7 @@ struct InterviewRecordingEndTestView: View {
                 Section {
                     HStack(spacing: 0){
                         TextField("이름", text: $vm.interview.details.userName)
+                            .foregroundColor(.black)
                             .onChange(of: vm.interview.details.userName) { text in
                                 isValid = text.count != 0 ? true : false
                             }
@@ -33,7 +34,9 @@ struct InterviewRecordingEndTestView: View {
                     } // HStack
                     
                     TextField("이메일", text: $vm.interview.details.userEmail)
+                        .foregroundColor(.black)
                     TextField("전화번호", text: $vm.interview.details.userPhoneNumber)
+                        .foregroundColor(.black)
                 } header: {
                     Text("대상자 정보")
                 } footer: {
@@ -53,17 +56,15 @@ struct InterviewRecordingEndTestView: View {
                     Button("완료") {
                         isShowingList.toggle()
                         print(vm.interview)
-
                     }
+                    .foregroundColor(isValid ? .accentColor : .gray)
+                    .disabled(!isValid)
                     // 모달에서 새화면으로 바꿔야함
                     .sheet(isPresented: $isShowingList, content: {
-
                         InterviewDetailTestView(vm: vm)
                     })
-                    .foregroundColor(isValid ? .accentColor : .gray)
                 }
             }// toolbar
-//        }//NavigationView
     }
 }
 


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
관련 이슈: #42 

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

- MainRecordView에서 수정된 사항
    - MainRecordView에 TestView의 기능이 적용되었습니다.

- InterviewRecordingView에서 수정된 사항
    - MainRecordView에 TestView의 기능이 적용되었습니다.
    - InterviewRecordingEndView의 Navigation과 관련된 코드가 수정되었습니다.

- <b>InterviewRecordingEndTestView에서 수정된 사항</b>
    - TextField의 foregroundColor가 .black으로 적용되지 않는 버그가 수정되었습니다.
    - isValid가 false일 때 완료버튼이 활성화되는 버그가 수정되었습니다.
    - Navigation과 관련된 코드가 수정되었습니다.

- <b>VoiceViewModel에서 수정된 사항</b>
    - initInterview에서 record와 STT 배열이 초기화되는 기능이 추가되었습니다.
    
- 후속 작업 사항
    - **RENAME** : InterviewRecordingEndTestView -> InterviewRecordingEndView
    - RENAME 이후 TestView 완전 삭제
    - 관련 뷰 코드 리팩터링
