### PR TITLE
Feat/#47 fix interviewrecordingview animation

### DIFF
--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -28,6 +28,8 @@ struct InterviewRecordingView: View {
     @State private var topImageOffsetY = CGFloat.zero
     @State private var isShowingTopImage = true
     @Binding var isShownInterviewRecordingView: Bool
+    @State var isShowingCancelAlert = false
+    
     
     // 타이머 시간 포맷
     func formattedDuration(_ duration: TimeInterval) -> String {
@@ -76,11 +78,21 @@ struct InterviewRecordingView: View {
                 VStack {
                     HStack { // 컨트롤 영역 (일시정지 및 재생 + 완료)
                         Button {
-                            self.isShownInterviewRecordingView.toggle()
+                            self.isShowingCancelAlert.toggle()
                         } label: {
                             Text("취소")
                                 .foregroundColor(Color.red)
                                 .font(.headline)
+                        }
+                        .alert(isPresented: $isShowingCancelAlert) {
+                            Alert(
+                                title: Text("녹음 취소"),
+                                message: Text("진행중인 녹음이 삭제됩니다."),
+                                primaryButton: .destructive(Text("녹음 취소")) {
+                                    self.isShownInterviewRecordingView.toggle()
+                                },
+                                secondaryButton: .cancel(Text("되돌아가기"))
+                            )
                         }
                         .position(
                             x: UIScreen.main.bounds.width / 6.5,
@@ -185,7 +197,7 @@ struct InterviewRecordingView: View {
                                 Text("완료")
                                     .font(.headline)
                                 // 녹음 중일때 -> 회색, 녹음 일시정지일때 -> 빨간색
-                                    .foregroundColor(!isPaused ? Color(red: 117/255, green: 117/255, blue: 117/255) : Color.red)
+                                    .foregroundColor(!isPaused ? Color.BackgroundGray_Dark : Color.red)
                                 // 녹음 중일 때 완료 버튼 비활성화
                                     .position(
                                         x: UIScreen.main.bounds.width / 6,

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -19,7 +19,14 @@ struct InterviewRecordingView: View {
     @State private var speakerSwitch: Color = SpeakerSwitch.speakerOne
     @State private var timer: Timer? = nil
     @State private var visualColor: Color = Color(red: 1.0, green: 166/255, blue: 0.0)
-    
+    @State private var isChevronAnimating = false
+    @State private var isBottomImage = true
+    @State private var bottomImageOffsetY = CGFloat.zero
+    @State private var isShowingBottomImage = true
+    @State private var initChevronOffsetYValue = CGFloat.zero
+    @State private var isTopImage = true
+    @State private var topImageOffsetY = CGFloat.zero
+    @State private var isShowingTopImage = true
     @Binding var isShownInterviewRecordingView: Bool
     
     // 타이머 시간 포맷
@@ -63,31 +70,98 @@ struct InterviewRecordingView: View {
             stopTimer()
         }
     }
-    
     var body: some View {
         NavigationView{
-            VStack { // 컨트롤 영역 + 화자전환 영역 + 오디오 비주얼라이저 영역
-                HStack { // 컨트롤 영역 (일시정지 및 재생 + 완료)
-                    Button {
-                        self.isShownInterviewRecordingView.toggle()
-                    } label: {
-                        Text("취소")
-                            .foregroundColor(Color.red)
-                            .font(.headline)
-                    }
-                    .position(
-                        x: UIScreen.main.bounds.width / 6.5,
-                        y: UIScreen.main.bounds.height * 0.02
-                    )
-                    
-                    // 일시정지 및 재생 버튼 로직
-                    Button(action: {
-                        isRecording.toggle()
-                        if isRecording {
+            ZStack {
+                VStack {
+                    HStack { // 컨트롤 영역 (일시정지 및 재생 + 완료)
+                        Button {
+                            self.isShownInterviewRecordingView.toggle()
+                        } label: {
+                            Text("취소")
+                                .foregroundColor(Color.red)
+                                .font(.headline)
+                        }
+                        .position(
+                            x: UIScreen.main.bounds.width / 6.5,
+                            y: UIScreen.main.bounds.height * 0.02
+                        )
+                        
+                        // 일시정지 및 재생 버튼 로직
+                        Button(action: {
+                            isRecording.toggle()
+                            if isRecording {
+                                // 녹음 중일때 -> 녹음 시작 및 타이머 시작
+                                isPaused = false
+                                audioInputManager.startRecording { buffer in
+                                    DispatchQueue.main.async { }
+                                }
+                                startTimer()
+                                // 녹음 중일때 or 일시정지일 떄 오디오 비주얼라이저 색상 변경
+                                if speakerSwitch == SpeakerSwitch.speakerOne {
+                                    visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
+                                } else {
+                                    visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
+                                }
+                                vm.startRecording()
+                            } else {
+                                // 일시정지일때 -> 타이머 정지 및 오디오 비주얼라이저 끔
+                                audioInputManager.stopRecording()
+                                isPaused = true
+                                stopTimer()
+                                // 오디오 비주얼라이저 회색으로 비활성화 표시
+                                visualColor = Color.gray
+                                
+                                // 일단 먼저 녹음중지하고 기록함
+                                vm.stopRecording(
+                                    index: self.transcriptIndex,
+                                    recoder: vm.recoderType
+                                )
+                                self.transcriptIndex += 1
+                            }
+                        }) {
+                            // 일시정지 및 재생 버튼 UI
+                            RoundedRectangle(cornerRadius: 35)
+                            // 버튼 겉 stroke
+                                .stroke(!isPaused ? Color.white : Color.red, lineWidth: 3)
+                                .frame(width: 131, height: 44)
+                            // 버튼 속 fill
+                                .overlay(RoundedRectangle(cornerRadius: 35)
+                                    .frame(width: 119, height: 32)
+                                         // 녹음 중일때 -> 검정색, 녹음 일시정지일때 -> 빨간색
+                                    .foregroundColor(!isPaused ? Color.black : Color(red: 1.0, green: 0.0, blue: 0.0, opacity: 30/100))
+                                    .overlay(
+                                        HStack {
+                                            // 녹음 중일때 -> 일시정지 심볼, 녹음 일시정지일때 -> 재생 심볼
+                                            Image(systemName: !isPaused ? "pause.fill" : "play.fill")
+                                                .resizable()
+                                                .frame(width: 18, height: 18)
+                                                .foregroundColor(Color.red)
+                                            // 타이머 텍스트
+                                            Text(formattedDuration(duration))
+                                                .font(.title2)
+                                                .fontDesign(.rounded)
+                                                .fontWeight(.bold)
+                                                .foregroundColor(!isPaused ? Color.white : Color.red)
+                                                .frame(minWidth: 50)
+                                                .monospacedDigit()
+                                        }
+                                    )
+                                )
+                        }
+                        .position(
+                            x: UIScreen.main.bounds.width / 6.15,
+                            y: UIScreen.main.bounds.height * 0.02
+                        )
+                        .onAppear {
+                            vm.recoderType = Recorder.interviewer
+                            vm.startRecording()
+                            
+                            isRecording = true
                             // 녹음 중일때 -> 녹음 시작 및 타이머 시작
                             isPaused = false
                             audioInputManager.startRecording { buffer in
-                                DispatchQueue.main.async { }
+                                DispatchQueue.main.async {}
                             }
                             startTimer()
                             // 녹음 중일때 or 일시정지일 떄 오디오 비주얼라이저 색상 변경
@@ -96,190 +170,183 @@ struct InterviewRecordingView: View {
                             } else {
                                 visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
                             }
-                            vm.startRecording()
-                        } else {
-                            // 일시정지일때 -> 타이머 정지 및 오디오 비주얼라이저 끔
-                            audioInputManager.stopRecording()
-                            isPaused = true
-                            stopTimer()
-                            // 오디오 비주얼라이저 회색으로 비활성화 표시
-                            visualColor = Color.gray
-                            
-                            // 일단 먼저 녹음중지하고 기록함
-                            vm.stopRecording(
-                                index: self.transcriptIndex,
-                                recoder: vm.recoderType
-                            )
-                            self.transcriptIndex += 1
                         }
-                    }) {
-                        // 일시정지 및 재생 버튼 UI
-                        RoundedRectangle(cornerRadius: 35)
-                        // 버튼 겉 stroke
-                            .stroke(!isPaused ? Color.white : Color.red, lineWidth: 3)
-                            .frame(width: 131, height: 44)
-                        // 버튼 속 fill
-                            .overlay(RoundedRectangle(cornerRadius: 35)
-                                .frame(width: 119, height: 32)
-                                     // 녹음 중일때 -> 검정색, 녹음 일시정지일때 -> 빨간색
-                                .foregroundColor(!isPaused ? Color.black : Color(red: 1.0, green: 0.0, blue: 0.0, opacity: 30/100))
-                                .overlay(
-                                    HStack {
-                                        // 녹음 중일때 -> 일시정지 심볼, 녹음 일시정지일때 -> 재생 심볼
-                                        Image(systemName: !isPaused ? "pause.fill" : "play.fill")
-                                            .resizable()
-                                            .frame(width: 18, height: 18)
-                                            .foregroundColor(Color.red)
-                                        // 타이머 텍스트
-                                        Text(formattedDuration(duration))
-                                            .font(.title2)
-                                            .fontDesign(.rounded)
-                                            .fontWeight(.bold)
-                                            .foregroundColor(!isPaused ? Color.white : Color.red)
-                                            .frame(minWidth: 50)
-                                    }
-                                )
-                            )
-                    }
-                    .position(
-                        x: UIScreen.main.bounds.width / 6.15,
-                        y: UIScreen.main.bounds.height * 0.02
-                    )
-                    .onAppear {
-                        vm.recoderType = Recorder.interviewer
-                        vm.startRecording()
                         
-                        isRecording = true
-                        // 녹음 중일때 -> 녹음 시작 및 타이머 시작
-                        isPaused = false
-                        audioInputManager.startRecording { buffer in
-                            DispatchQueue.main.async {}
-                        }
-                        startTimer()
-                        // 녹음 중일때 or 일시정지일 떄 오디오 비주얼라이저 색상 변경
-                        if speakerSwitch == SpeakerSwitch.speakerOne {
-                            visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
-                        } else {
-                            visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
-                        }
-                    }
-                    
-                    // 완료 버튼 로직
-                    NavigationLink(
-                        destination: InterviewDetailEditModalView(vm: vm)
-                            .onTapGesture {
-                                // 완료버튼 누를 때 interview 인스턴스를 업데이트
-                                vm.interview.recordSTT = vm.transcripts
-                                vm.interview.records = vm.recordings
-                                vm.interview.details.playTime = formattedDuration(duration)
-                            },
-                        label: {
-                            Text("완료")
-                                .font(.headline)
-                            // 녹음 중일때 -> 회색, 녹음 일시정지일때 -> 빨간색
-                                .foregroundColor(!isPaused ? Color(red: 117/255, green: 117/255, blue: 117/255) : Color.red)
-                            // 녹음 중일 때 완료 버튼 비활성화
-                                .position(
-                                    x: UIScreen.main.bounds.width / 6,
-                                    y: UIScreen.main.bounds.height * 0.02
-                                )
-                        } //label
-                    ) // NavigationLink
-                    .navigationTitle("뒤로")
-                    .navigationBarHidden(true)
-                    .disabled(isRecording)
-                } // HStack
-                
-                // 화자 전환 기능
-                RoundedRectangle(cornerRadius: 44)
-                // 화자전환 영역
-                    .fill(Color(red: 28/255, green: 28/255, blue: 30/255))
-                    .frame(
-                        width: UIScreen.main.bounds.width * 0.95,
-                        height: UIScreen.main.bounds.height * 0.7
-                    )
-                // 화자전환 제스처
-                    .gesture(
-                        DragGesture(minimumDistance: 100, coordinateSpace: .local)
-                            
-                            .onEnded { value in
-                                let isDraggingDownward = (value.translation.height > 100 && speakerSwitch == SpeakerSwitch.speakerTwo) || (value.translation.height < -100 && speakerSwitch == SpeakerSwitch.speakerOne)
-                                withAnimation() {
-                                    if isDraggingDownward {
-                                        // 오디오 비주얼라이저 색상
-                                        if speakerSwitch == SpeakerSwitch.speakerOne {
-                                            speakerSwitch = SpeakerSwitch.speakerTwo
-                                            visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
-                                        } else {
-                                            speakerSwitch = SpeakerSwitch.speakerOne
-                                            visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
+                        // 완료 버튼 로직
+                        NavigationLink(
+                            destination: InterviewDetailEditModalView(vm: vm)
+                                .onTapGesture {
+                                    // 완료버튼 누를 때 interview 인스턴스를 업데이트
+                                    vm.interview.recordSTT = vm.transcripts
+                                    vm.interview.records = vm.recordings
+                                    vm.interview.details.playTime = formattedDuration(duration)
+                                },
+                            label: {
+                                Text("완료")
+                                    .font(.headline)
+                                // 녹음 중일때 -> 회색, 녹음 일시정지일때 -> 빨간색
+                                    .foregroundColor(!isPaused ? Color(red: 117/255, green: 117/255, blue: 117/255) : Color.red)
+                                // 녹음 중일 때 완료 버튼 비활성화
+                                    .position(
+                                        x: UIScreen.main.bounds.width / 6,
+                                        y: UIScreen.main.bounds.height * 0.02
+                                    )
+                            } //label
+                        ) // NavigationLink
+                        .navigationTitle("뒤로")
+                        .navigationBarHidden(true)
+                        .disabled(isRecording)
+                    } // HStack
+                    // 화자 전환 기능
+                    RoundedRectangle(cornerRadius: 44)
+                        // 화자전환 영역
+                        .fill(Color(red: 28/255, green: 28/255, blue: 30/255))
+                        .frame(
+                            width: UIScreen.main.bounds.width * 0.95,
+                            height: UIScreen.main.bounds.height * 0.74
+                        )
+                        // 화자전환 제스처
+                        .gesture(
+                            DragGesture()
+                                .onChanged { value in
+                                    if isBottomImage {
+                                        if bottomImageOffsetY > -100 {
+                                            bottomImageOffsetY = min(0, value.translation.height)
                                         }
+ 
+                                    } else {
                                         
-                                        if vm.isRecording {
-                                            // 화자바꾸지 않고 기록함
-                                            vm.stopRecording(
-                                                index: self.transcriptIndex,
-                                                recoder: vm.recoderType
-                                            )
-                                            self.transcriptIndex += 1
-                                            // 화자를 바꾸기
-                                            if vm.recoderType == Recorder.interviewer { // 인터뷰어일때
-                                                vm.recoderType = Recorder.interviewee // 화자 바꾸고
-                                            } else { // 인터뷰이일때
-                                                vm.recoderType = Recorder.interviewer
+                                        if topImageOffsetY < 100 {
+                                            topImageOffsetY = max(0, value.translation.height)
+                                        }
+
+
+                                    }
+                                    
+                                }
+                                .onEnded { value in
+                                    let isDraggingDownward = (value.translation.height > 100 && speakerSwitch == SpeakerSwitch.speakerTwo) || (value.translation.height < -100 && speakerSwitch == SpeakerSwitch.speakerOne)
+                                    withAnimation(.spring()) {
+                                        if isDraggingDownward {
+                                            // 오디오 비주얼라이저 색상
+                                            if speakerSwitch == SpeakerSwitch.speakerOne {
+                                                speakerSwitch = SpeakerSwitch.speakerTwo
+                                                visualColor = Color(red: 0.0, green: 234/255, blue: 223/255)
+                                                
+                                                //isShowingBottomImage = bottomImageOffsetY > -100
+                                                self.isChevronAnimating = true
+                                                
+                                                bottomImageOffsetY = 0
+                                                isShowingBottomImage = true
+                                                isBottomImage = false
+                                                isTopImage = true
+                                            } else {
+                                                speakerSwitch = SpeakerSwitch.speakerOne
+                                                visualColor = Color(red: 1.0, green: 166/255, blue: 0.0)
+                                                self.isChevronAnimating = false
+                                                
+                                                topImageOffsetY = 0
+                                                isShowingTopImage = true
+                                                isBottomImage = true
+                                                isTopImage = false
                                             }
-                                            vm.startRecording()
-                                        } else {
-                                            // 화자를 바꾸기
-                                            if vm.recoderType == Recorder.interviewer { // 인터뷰어일때
-                                                vm.recoderType = Recorder.interviewee // 화자 바꾸고
-                                            } else { // 인터뷰이일때
-                                                vm.recoderType = Recorder.interviewer
+                                            
+                                            if vm.isRecording {
+                                                // 화자바꾸지 않고 기록함
+                                                vm.stopRecording(
+                                                    index: self.transcriptIndex,
+                                                    recoder: vm.recoderType
+                                                )
+                                                self.transcriptIndex += 1
+                                                // 화자를 바꾸기
+                                                if vm.recoderType == Recorder.interviewer { // 인터뷰어일때
+                                                    vm.recoderType = Recorder.interviewee // 화자 바꾸고
+                                                } else { // 인터뷰이일때
+                                                    vm.recoderType = Recorder.interviewer
+                                                }
+                                                vm.startRecording()
+                                            } else {
+                                                // 화자를 바꾸기
+                                                if vm.recoderType == Recorder.interviewer { // 인터뷰어일때
+                                                    vm.recoderType = Recorder.interviewee // 화자 바꾸고
+                                                } else { // 인터뷰이일때
+                                                    vm.recoderType = Recorder.interviewer
+                                                }
                                             }
+                                        }
+                                        else {
+                                            bottomImageOffsetY = 0
+                                            topImageOffsetY = 0
+                                            initChevronOffsetYValue = 0
                                         }
                                     }
                                 }
-                                
-                            }
-                            
-                    )
-                // 화자전환 가이드
-                    .overlay(alignment: .bottom) {
-                        Group {
-                            if speakerSwitch == SpeakerSwitch.speakerOne {
-                                // 내가 화자일때
-                                VStack {
-                                    Image(systemName: "chevron.compact.up")
-                                        .resizable()
-                                        .frame(width: 34, height: 10)
-                                        .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
-                                        .padding(.bottom, 10)
-                                    Text("쓸어올려 상대로 전환")
-                                        .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
+                        )
+                        // 화자전환 제스처 가이드
+                        .overlay {
+                            Group {
+                                if speakerSwitch == SpeakerSwitch.speakerOne {
+                                    // 내가 화자일때
+                                    if isShowingBottomImage {
+                                        VStack(spacing: 20) {
+                                            Image(systemName: "chevron.compact.up")
+                                                .resizable()
+                                                .frame(width: 34, height: 10)
+                                                .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
+                                                .offset(x: 0, y: isChevronAnimating ? initChevronOffsetYValue - 30 : initChevronOffsetYValue)
+                                                .animation(.easeInOut(duration: 1.4).repeatForever(autoreverses: false), value: isChevronAnimating)
+                                                .opacity(isChevronAnimating ? 1 : 0)
+                                                .animation(.easeOut(duration: 0.7).repeatForever(autoreverses: true), value: isChevronAnimating)
+                                                .onAppear {
+                                                    self.isChevronAnimating = true
+                                                }
+                                            Text("쓸어올려 상대로 전환")
+                                                .foregroundColor(Color(red: 1.0, green: 166/255, blue: 0.0))
+                                        }
+                                        .offset(y: bottomImageOffsetY)
+                                        .padding(.top, UIScreen.main.bounds.height / 2)
+                                        .onAppear {
+                                            
+                                        }
+                                    }
+                                } else {
+                                    // 상대가 화자일때
+                                    if isShowingBottomImage {
+                                        VStack(spacing: 20) {
+                                            Text("쓸어내려 나로 전환")
+                                                .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
+                                            Image(systemName: "chevron.compact.down")
+                                                .resizable()
+                                                .frame(width: 34, height: 10)
+                                                .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
+                                                .offset(x: 0, y: !isChevronAnimating ? 30 + initChevronOffsetYValue : initChevronOffsetYValue)
+                                                .animation(.easeInOut(duration: 1.4).repeatForever(autoreverses: false), value: !isChevronAnimating)
+                                                .opacity(isChevronAnimating ? 0 : 1)
+                                                .animation(.easeOut(duration: 0.7).repeatForever(autoreverses: true), value: !isChevronAnimating)
+                                                .onAppear {
+                                                    self.isChevronAnimating = false
+                                                }
+                                        }
+                                        .offset(y: topImageOffsetY)
+                                        .padding(.bottom, UIScreen.main.bounds.height / 2)
+                                        .onAppear {
+                                            
+                                        }
+                                    }
                                 }
-                            } else {
-                                // 상대가 화자일때
-                                VStack{
-                                    Spacer()
-                                        .frame(height: 480)
-                                    Image(systemName: "chevron.compact.down")
-                                        .resizable()
-                                        .frame(width: 34, height: 10)
-                                        .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
-                                        .padding(.bottom, 10)
-                                    Text("쓸어내려 나로 전환")
-                                        .foregroundColor(Color(red: 0.0, green: 234/255, blue: 223/255))
-                                }
                             }
+                            .font(.headline)
+                            .fontWeight(.bold)
                         }
-                        .padding(.bottom, 80)
-                        .font(.headline)
-                        .fontWeight(.bold)
-                    }
-                
+                        .position(
+                            x: UIScreen.main.bounds.width / 2,
+                            y: UIScreen.main.bounds.height * 0.006
+                        )
+                } // VStack
                 // 오디오 비쥬얼라이저 뷰
                 AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording, isPaused: $isPaused, audioVisualizerColor: $visualColor)
-            } // VStack
+                    .position(x: UIScreen.main.bounds.width / 2, y: UIScreen.main.bounds.height * 0.87)
+            } // ZStack
             .frame(
                 maxWidth: .infinity,
                 maxHeight: .infinity


### PR DESCRIPTION
## 개요 및 관련 이슈
관련 이슈 : #47 

## 작업 사항

1. 기본 상태 Chevron에 스와이프 유도 애니메이션 구현
2. 화자전환 제스처 시 제스처 가이드(Chevron+Text) 애니메이션 구현
3. 취소 Alert 구현
4. 타이머를 monospace로 변경
5. 완료 버튼이 눈에 덜 띄게 색상 변경

## 후속 작업
1. 화자 전환 제스처 시 특정 상황에서 Chevron 애니메이션 버그 수정
2. 기본 상태 중 Chevron 애니메이션이 시간이 지날수록 opacity값이 틀어지는 문제 수정
3. 화자 전환 제스처 시 제스처 가이드가 자연스럽게 사라지도록 수정
4. 취소 Alert의 버튼이 제대로 눌리지 않는 문제 수정
