### PR TITLE
Feat/#51 implement permission manager

### DIFF
--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		608D9D702A014BEE001E8E3C /* VoiceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608D9D6F2A014BEE001E8E3C /* VoiceViewModel.swift */; };
 		608D9D7D2A01F673001E8E3C /* InterviewDetailTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608D9D7C2A01F673001E8E3C /* InterviewDetailTestView.swift */; };
 		608D9D7F2A022F5E001E8E3C /* MainTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608D9D7E2A022F5E001E8E3C /* MainTestView.swift */; };
+		60D579B02A0E17C60006D884 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D579AF2A0E17C60006D884 /* PermissionManager.swift */; };
 		7E6E395D2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6E395C2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift */; };
 		7E6E395F2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6E395E2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift */; };
 		7E74F30B2A0CDB4700D03AF3 /* RoutingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E74F30A2A0CDB4700D03AF3 /* RoutingManager.swift */; };
@@ -52,6 +53,7 @@
 		608D9D7C2A01F673001E8E3C /* InterviewDetailTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewDetailTestView.swift; sourceTree = "<group>"; };
 		608D9D7E2A022F5E001E8E3C /* MainTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTestView.swift; sourceTree = "<group>"; };
 		608D9D802A026014001E8E3C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		60D579AF2A0E17C60006D884 /* PermissionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
 		7E6E395C2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewDetailEditModalView.swift; sourceTree = "<group>"; };
 		7E6E395E2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewDetailChatEditModalView.swift; sourceTree = "<group>"; };
 		7E74F30A2A0CDB4700D03AF3 /* RoutingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingManager.swift; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				608D9D6F2A014BEE001E8E3C /* VoiceViewModel.swift */,
 				C91E4D302A0A545800E5F983 /* InterviewViewModel.swift */,
 				7E74F30A2A0CDB4700D03AF3 /* RoutingManager.swift */,
+				60D579AF2A0E17C60006D884 /* PermissionManager.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -330,6 +333,7 @@
 				608D9D702A014BEE001E8E3C /* VoiceViewModel.swift in Sources */,
 				608D9D7D2A01F673001E8E3C /* InterviewDetailTestView.swift in Sources */,
 				C91E4D312A0A545800E5F983 /* InterviewViewModel.swift in Sources */,
+				60D579B02A0E17C60006D884 /* PermissionManager.swift in Sources */,
 				7EDEB0D52A011DF600176D72 /* MainInterviewList.swift in Sources */,
 				6072D0E52A053E93005583FC /* Interview.swift in Sources */,
 				601CCC4D2A08D53F005B02C7 /* Date+.swift in Sources */,

--- a/Pressor/Pressor/PressorApp.swift
+++ b/Pressor/Pressor/PressorApp.swift
@@ -10,10 +10,16 @@ import SwiftUI
 @main
 struct PressorApp: App {
     @ObservedObject var routeManager: RoutingManager = .init()
+    @ObservedObject var permissionManager: PermissionManager = .init()
     var body: some Scene {
         WindowGroup {
             MainRecordView()
                 .environmentObject(routeManager)
+                .onAppear {
+                    permissionManager.requestAudioPermission()
+                    permissionManager.requestRecordingPermission()
+                    permissionManager.requestSpeechRecognizerPermission()
+                }
         }
     }
 }

--- a/Pressor/Pressor/ViewModels/PermissionManager.swift
+++ b/Pressor/Pressor/ViewModels/PermissionManager.swift
@@ -1,0 +1,96 @@
+//
+//  PermissionManager.swift
+//  Pressor
+//
+//  Created by 홍승완 on 2023/05/12.
+//
+
+import AVFoundation
+import Speech
+
+class PermissionManager : ObservableObject {
+    var recordingSession: AVAudioSession!
+    var audioRecorder: AVAudioRecorder!
+    /**
+     * 음성녹음 권한을 요청합니다.
+     */
+    func requestRecordingPermission() {
+        // Singleton 인스턴스를 얻어온다.
+        recordingSession = AVAudioSession.sharedInstance()
+        
+        do {
+            // 오디오 세션의 카테고리와 모드를 설정한다.
+            try recordingSession.setCategory(.playAndRecord, mode: .default)
+            try recordingSession.setActive(true)
+            // 음성 녹음 권한을 요청한다.
+            recordingSession.requestRecordPermission() { allowed in
+                if allowed {
+                    print("Record: 권한 허용")
+                } else {
+                    print("Record: 권한 거부")
+                }
+            }
+        } catch {
+            print("음성 녹음 실패")
+        }
+    }
+    
+    /**
+     * 음성인식 권한을 요청합니다.
+     */
+    func requestSpeechRecognizerPermission() {
+        // Initialize the speech recogniter with your preffered language
+        guard let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "ko_KR")) else {
+            print("Speech recognizer is not available for this locale!")
+            return
+        }
+        
+        // Check the availability. It currently only works on the device
+        if (speechRecognizer.isAvailable == false) {
+            print("Speech recognizer is not available for this device!")
+            return
+        }
+        
+        // Make the authorization request
+        SFSpeechRecognizer.requestAuthorization { authStatus in
+            
+            // The authorization status results in changes to the
+            // app’s interface, so process the results on the app’s
+            // main queue.
+            OperationQueue.main.addOperation {
+                switch authStatus {
+                case .authorized:
+                    print("Speech Recognizer: 권한 허용")
+
+                case .denied:
+                    print("Speech Recognizer: 권한 거부")
+                    
+                case .restricted:
+                    print("Speech Recognizer: restricted")
+                    
+                case .notDetermined:
+                    print("Speech Recognizer: notDetermined")
+                
+                @unknown default:
+                    fatalError()
+                }
+            }
+        }
+    }
+    
+    
+    
+    /**
+     * 오디오 권한을  요청합니다.
+     */
+    func requestAudioPermission(){
+        AVCaptureDevice.requestAccess(for: .audio, completionHandler: { (granted: Bool) in
+            if granted {
+                print("Audio: 권한 허용")
+            } else {
+                print("Audio: 권한 거부")
+            }
+        })
+    }
+    
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
관련 이슈 : https://github.com/DeveloperAcademy-POSTECH/MC2_2thCo.6thPlatoon/issues/51

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
 녹음, 오디오, 음성인식 관련 권한요청을 관리하는 PermissionManager을 생성합니다.
 최초 보여지는 MainRecordView에서 PermissionManager의 여러 권한요청을 하는 메소드를 적용합니다.

### PressorApp
```diff
struct PressorApp: App {
+    @ObservedObject var routeManager: RoutingManager = .init()
    @ObservedObject var permissionManager: PermissionManager = .init()
    var body: some Scene {
        WindowGroup {
            MainRecordView()
                .environmentObject(routeManager)
+               .onAppear {
+                    permissionManager.requestAudioPermission()
+                    permissionManager.requestRecordingPermission()
+                    permissionManager.requestSpeechRecognizerPermission()
+                }
        }
    }
}
```

### PermissionManager
```diff
class PermissionManager : ObservableObject {
+func requestRecordingPermission() {} // 녹음 관련 권한 요청
+func requestSpeechRecognizerPermission() {} // 음성인식 관련 권한 요청
+func requestAudioPermission() {} // 오디오 관련 권한 요청
}
```

