### PR TITLE
Feat/#48 responding script view ux changes

### DIFF
--- a/Pressor/Pressor/Models/InterviewScriptModel.swift
+++ b/Pressor/Pressor/Models/InterviewScriptModel.swift
@@ -8,10 +8,6 @@
 import Foundation
 
 struct Script {
-    var scriptTitle: String
-    var scriptContent: String
-}
-
-struct InterviewScriptModel {
-    var interviewScripts: [Script]
+    var title: String
+    var description: String
 }

--- a/Pressor/Pressor/ViewModels/InterviewViewModel.swift
+++ b/Pressor/Pressor/ViewModels/InterviewViewModel.swift
@@ -1,3 +1,5 @@
+
+//
 //  InterviewViewModel.swift
 //  Pressor
 //
@@ -7,35 +9,25 @@
 import Foundation
 
 class InterviewViewModel: ObservableObject {
-    // 인터뷰 목록
-    @Published var interviewScriptModel: InterviewScriptModel
+    // Current script
+    @Published var script: Script
     
+    // VoiceViewModel
+    var voiceViewModel: VoiceViewModel
+
     // Default initializer
-    init() {
-        self.interviewScriptModel = InterviewScriptModel(interviewScripts: [])
+    init(voiceViewModel: VoiceViewModel) {
+        self.voiceViewModel = voiceViewModel
+        self.script = Script(title: "", description: "")
     }
     
-    // 대본 생성
-    func createScript(title: String, content: String) {
-        // 대본 추가
-        interviewScriptModel.interviewScripts.append(Script(scriptTitle: title, scriptContent: content))
+    // 대본 수정(추가, 삭제 - 공백으로 바꿀 경우)
+    func setScript(title: String, description: String) {
+        self.script = Script(title: title, description: description)
     }
     
-    // 대본 읽기
-    func getScripts() -> [Script] {
-        // 대본 목록 반환
-        return interviewScriptModel.interviewScripts
-    }
-    
-    // 대본 수정
-    func updateScript(title: String, content: String, atIndex index: Int) {
-        // 대본 수정
-        interviewScriptModel.interviewScripts[index] = Script(scriptTitle: title, scriptContent: content)
-    }
-    
-    // 대본 삭제
-    func deleteScript(atIndex index: Int) {
-        // 대본 삭제
-        interviewScriptModel.interviewScripts.remove(at: index)
+    // 대본 가져오기
+    func getScript() -> Script {
+        return self.script
     }
 }

--- a/Pressor/Pressor/ViewModels/VoiceViewModel.swift
+++ b/Pressor/Pressor/ViewModels/VoiceViewModel.swift
@@ -33,17 +33,22 @@ class VoiceViewModel : NSObject, ObservableObject , AVAudioPlayerDelegate{
     public var date: Date = Date()
     private var playingURL : URL?
     
+    
+    // TODO: Script create
+    public var script: Script = Script(title: "", description: "")
+    
     init(interview: Interview){
         self.interview = interview
     }
     
     public func initInterview() {
         //메인뷰에서 마이크를 탭하는 시점에서 Interview 인스턴스를 생성하도록 변경
+        // MARK: 메인뷰 onAppear 시점에 initInterview를 실행하고, interviewViewModel에 의존성 부여하도록 설정
         let fileManager = FileManager.default
         let documentUrl = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
         
         // TODO: 인터뷰 저장하지 않을 시 해당 경로의 모든 정보 삭제해야함
-        var interview: Interview = Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(scriptTitle: "", scriptContent: ""))
+        var interview: Interview = Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: ""))
         
         let directoryPath = documentUrl.appendingPathComponent("\(interview.id)")
         
@@ -61,6 +66,7 @@ class VoiceViewModel : NSObject, ObservableObject , AVAudioPlayerDelegate{
         }
         
         self.interview = interview
+        self.interview.script = self.script
         self.interviewPath = directoryPath
         
         // vm의 recording과 STT배열 초기화

--- a/Pressor/Pressor/Views/InterviewViews/InterviewModals/InterviewDetailEditModalView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewModals/InterviewDetailEditModalView.swift
@@ -77,6 +77,6 @@ struct InterviewDetailEditModalView: View {
 struct PreviewT: PreviewProvider {
     static var previews: some View {
         InterviewDetailEditModalView(vm: VoiceViewModel(
-            interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(scriptTitle: "", scriptContent: ""))))
+            interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: ""))))
     }
 }

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -302,7 +302,7 @@ struct InterviewRecordingView_Previews: PreviewProvider {
     static var previews: some View {
         InterviewRecordingView(
             vm: VoiceViewModel(
-                interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: Script(scriptTitle: "", scriptContent: "")))
+                interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: Script(title: "", description: "")))
             , isShownInterviewRecordingView: .constant(false)
         )
     }

--- a/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
+++ b/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
@@ -17,37 +17,26 @@ struct AddScriptModalView: View {
     // 화면 전환을 관리하는 presentationMode를 사용하여 모달 창을 닫을 수 있도록 하는 변수
     @Environment(\.presentationMode) private var presentationMode
     
-    @ObservedObject var interviewViewModel : InterviewViewModel
-    
+    @ObservedObject var interviewViewModel: InterviewViewModel
+    @ObservedObject var voiceViewModel: VoiceViewModel
     // 외부에서 전달된 scriptAdded를 바인딩하여 완료 버튼을 눌렀을 때 업데이트
     @Binding var scriptAdded: Bool
     
-    // 현재 인터뷰 스크립트의 index (수정 모드인 경우 필요)
-    var scriptIndex: Int?
+    @State private var title: String
+    @State private var description: String
+    
+    // 뷰의 모드를 결정하는 변수
+    let mode: ScriptMode
     
     // 초기화 메서드
-    init(mode: ScriptMode, scriptAdded: Binding<Bool>, interviewViewModel: InterviewViewModel, scriptIndex: Int? = nil) {
-        self.mode = mode
-        self._scriptAdded = scriptAdded
+    init(interviewViewModel: InterviewViewModel, voiceViewModel: VoiceViewModel, scriptAdded: Binding<Bool>, title: String, description: String, mode: ScriptMode) {
         self.interviewViewModel = interviewViewModel
-        self.scriptIndex = scriptIndex
-        
-        // 수정 모드인 경우, 현재 스크립트의 정보로 초기값 설정
-        if let scriptIndex = scriptIndex, mode == .edit {
-            let scripts = interviewViewModel.getScripts()
-            self._title = State(initialValue: scripts[scriptIndex].scriptTitle)
-            self._bodyText = State(initialValue: scripts[scriptIndex].scriptContent)
-        } else {
-            self._title = State(initialValue: "")
-            self._bodyText = State(initialValue: "")
-        }
+        self.voiceViewModel = voiceViewModel
+        _scriptAdded = scriptAdded
+        _title = State(initialValue: title)
+        _description = State(initialValue: description)
+        self.mode = mode
     }
-    
-    @State private var title: String
-    @State private var bodyText: String
-    
-    // 뷰의 모드를 결정하는 변수 추가
-    let mode: ScriptMode
     
     // 메인 뷰
     var body: some View {
@@ -76,11 +65,11 @@ struct AddScriptModalView: View {
     // 본문 입력 에디터
     private var bodyTextEditor: some View {
         ZStack(alignment: .topLeading) {
-            TextEditor(text: $bodyText)
+            TextEditor(text: $description)
                 .frame(height: 270)
                 .padding(.leading, -4)
             
-            if bodyText.isEmpty {
+            if description.isEmpty {
                 // 본문이 비어있을 때만 "본문" 텍스트 표시
                 Text("본문")
                     .foregroundColor(.gray.opacity(0.5))
@@ -104,11 +93,10 @@ struct AddScriptModalView: View {
             if isInputValid() {
                 switch mode {
                 case .add:
-                    interviewViewModel.createScript(title: title, content: bodyText)
+                    interviewViewModel.setScript(title: title, description: description)
                 case .edit:
-                    if let index = scriptIndex {
-                        interviewViewModel.updateScript(title: title, content: bodyText, atIndex: index)
-                    }
+                    interviewViewModel.setScript(title: title, description: description)
+                    voiceViewModel.script = interviewViewModel.getScript()
                 }
                 // 제목과 본문을 입력한 경우, scriptAdded를 true로 설정하고 모달 창 종료
                 scriptAdded = true
@@ -124,6 +112,6 @@ struct AddScriptModalView: View {
 private extension AddScriptModalView {
     // 제목과 본문을 입력했는지 확인하는 함수
     func isInputValid() -> Bool {
-        return !title.isEmpty && !bodyText.isEmpty
+        return !title.isEmpty && !description.isEmpty
     }
 }

--- a/Pressor/Pressor/Views/RecordViews/AudioVisualizerView.swift
+++ b/Pressor/Pressor/Views/RecordViews/AudioVisualizerView.swift
@@ -21,21 +21,15 @@ struct AudioVisualizerView: View {
     @State private var barHeights: [CGFloat] = Array(repeating: 0, count: 40)
     
     var body: some View {
-        VStack {
-            ZStack {
-                HStack {
-                    HStack(spacing: 3) {
-                        // 각 막대를 생성, 높이와 애니메이션 적용.
-                        ForEach(0..<barHeights.count, id: \.self) { index in
-                            BarView(
-                                height: barHeights[index] * weight(for: index),
-                                isRecording: isRecording,
-                                audioVisualColor: audioVisualizerColor
-                            )
-                                .animation(.easeInOut(duration: 0.15), value: barHeights[index])
-                        }
-                    }
-                }
+        HStack(spacing: 3) {
+            // 각 막대를 생성, 높이와 애니메이션 적용.
+            ForEach(0..<barHeights.count, id: \.self) { index in
+                BarView(
+                    height: barHeights[index] * weight(for: index),
+                    isRecording: isRecording,
+                    audioVisualColor: audioVisualizerColor
+                )
+                .animation(.easeInOut(duration: 0.15), value: barHeights[index])
             }
         }
         .frame(width: 250, height: 80)
@@ -95,12 +89,12 @@ extension AudioVisualizerView {
         let sampleCount = samples.count
         let blockSize = sampleCount / barHeights.count
         let maxHeight = UIScreen.main.bounds.height / 3
-
+        
         for i in 0..<barHeights.count {
             let start = i * blockSize
             let end = start + blockSize
             let slice = samples[start..<end]
-
+            
             let rms = calculateRMS(for: Array(slice))
             let normalizedHeight = CGFloat(min(max(0, rms), 1)) * maxHeight
             barHeights[i] = min(max(normalizedHeight, 0), maxHeight)

--- a/Pressor/Pressor/Views/TestViews/EditInterviewScriptTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/EditInterviewScriptTestView.swift
@@ -1,46 +1,46 @@
+////
+////  EditInterviewScriptTestView.swift
+////  Pressor
+////
+////  Created by Ha Jong Myeong on 2023/05/10.
+////
 //
-//  EditInterviewScriptTestView.swift
-//  Pressor
+//import SwiftUI
 //
-//  Created by Ha Jong Myeong on 2023/05/10.
+//struct EditInterviewScriptTestView: View {
+//    @ObservedObject var viewModel: InterviewViewModel
+//    @Environment(\.presentationMode) var presentationMode
+//    @State private var title: String
+//    @State private var content: String
+//    let index: Int
 //
-
-import SwiftUI
-
-struct EditInterviewScriptTestView: View {
-    @ObservedObject var viewModel: InterviewViewModel
-    @Environment(\.presentationMode) var presentationMode
-    @State private var title: String
-    @State private var content: String
-    let index: Int
-    
-    init(viewModel: InterviewViewModel, index: Int, updatedTitle: String, updatedContent: String) {
-        self.viewModel = viewModel
-        self._title = State(wrappedValue: updatedTitle)
-        self._content = State(wrappedValue: updatedContent)
-        self.index = index
-    }
-    
-    var body: some View {
-        VStack {
-            TextField("Enter title", text: $title)
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-            TextField("Enter content", text: $content)
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-            Button(action: {
-                viewModel.updateScript(title: title, content: content, atIndex: index)
-                        presentationMode.wrappedValue.dismiss()
-            }) {
-                Text("Update Interview Script")
-                    .bold()
-                    .foregroundColor(.white)
-                    .padding()
-                    .background(Color.green)
-                    .cornerRadius(8)
-            }
-            Spacer()
-        }
-        .padding()
-        .navigationTitle("Edit Interview Script")
-    }
-}
+//    init(viewModel: InterviewViewModel, index: Int, updatedTitle: String, updatedContent: String) {
+//        self.viewModel = viewModel
+//        self._title = State(wrappedValue: updatedTitle)
+//        self._content = State(wrappedValue: updatedContent)
+//        self.index = index
+//    }
+//    
+//    var body: some View {
+//        VStack {
+//            TextField("Enter title", text: $title)
+//                .textFieldStyle(RoundedBorderTextFieldStyle())
+//            TextField("Enter content", text: $content)
+//                .textFieldStyle(RoundedBorderTextFieldStyle())
+//            Button(action: {
+//                viewModel.updateScript(title: title, content: content, atIndex: index)
+//                        presentationMode.wrappedValue.dismiss()
+//            }) {
+//                Text("Update Interview Script")
+//                    .bold()
+//                    .foregroundColor(.white)
+//                    .padding()
+//                    .background(Color.green)
+//                    .cornerRadius(8)
+//            }
+//            Spacer()
+//        }
+//        .padding()
+//        .navigationTitle("Edit Interview Script")
+//    }
+//}

--- a/Pressor/Pressor/Views/TestViews/InterviewDetailTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/InterviewDetailTestView.swift
@@ -90,6 +90,6 @@ struct InterviewDetailTestView: View {
 
 struct recordingListView_Previews: PreviewProvider {
     static var previews: some View {
-        InterviewDetailTestView(vm: VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(scriptTitle: "", scriptContent: ""))))
+        InterviewDetailTestView(vm: VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: ""))))
     }
 }

--- a/Pressor/Pressor/Views/TestViews/InterviewRecordingEndTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/InterviewRecordingEndTestView.swift
@@ -71,7 +71,7 @@ struct InterviewRecordingEndTestView: View {
 struct InterviewRecordingEndModalTestView_Previews: PreviewProvider {
     static var previews: some View {
         InterviewRecordingEndTestView(vm: VoiceViewModel(
-            interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(scriptTitle: "", scriptContent: "")))
+            interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: "")))
         )
     }
 }

--- a/Pressor/Pressor/Views/TestViews/InterviewRecordingTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/InterviewRecordingTestView.swift
@@ -301,6 +301,6 @@ struct InterviewRecordingTestView: View {
 
 struct InterviewRecordingTestView_Previews: PreviewProvider {
     static var previews: some View {
-        InterviewRecordingTestView(vm: VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(scriptTitle: "", scriptContent: ""))))
+        InterviewRecordingTestView(vm: VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: ""))))
     }
 }

--- a/Pressor/Pressor/Views/TestViews/InterviewScriptTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/InterviewScriptTestView.swift
@@ -1,67 +1,67 @@
-// ScriptTestView.swift
-// Pressor
+//// ScriptTestView.swift
+//// Pressor
+////
+//// Created by Ha Jong Myeong on 2023/05/09.
+////
 //
-// Created by Ha Jong Myeong on 2023/05/09.
+//import SwiftUI
 //
-
-import SwiftUI
-
-struct InterviewScriptTestView: View {
-    @StateObject var viewModel: InterviewViewModel
-    @State private var newTitle = ""
-    @State private var newContent = ""
-    @State private var showEditInterviewScriptView = false
-    @State private var editInterviewScriptIndex = 0
-    
-    var body: some View {
-        NavigationView {
-            VStack {
-                List {
-                    ForEach(viewModel.interviewScriptModel.interviewScripts.indices, id: \.self) { index in
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(viewModel.interviewScriptModel.interviewScripts[index].scriptTitle)
-                                .font(.headline)
-                            Text(viewModel.interviewScriptModel.interviewScripts[index].scriptContent)
-                        }
-                        .onTapGesture {
-                            editInterviewScriptIndex = index
-                            showEditInterviewScriptView.toggle()
-                        }
-                    }
-                    .onDelete(perform: deleteInterviewScript)
-                }
-                
-                VStack(spacing: 12) {
-                    TextField("Enter title", text: $newTitle)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                    TextField("Enter content", text: $newContent)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                    Button(action: {
-                        viewModel.createScript(title: newTitle, content: newContent)
-                        newTitle = ""
-                        newContent = ""
-                    }) {
-                        Text("Add Interview Script")
-                            .bold()
-                            .foregroundColor(.white)
-                            .padding()
-                            .background(Color.blue)
-                            .cornerRadius(8)
-                    }
-                }
-                .padding()
-                
-            }
-            .navigationTitle("Interview Scripts")
-            .sheet(isPresented: $showEditInterviewScriptView) {
-                EditInterviewScriptTestView(viewModel: viewModel, index: editInterviewScriptIndex, updatedTitle: viewModel.interviewScriptModel.interviewScripts[editInterviewScriptIndex].scriptTitle, updatedContent: viewModel.interviewScriptModel.interviewScripts[editInterviewScriptIndex].scriptContent)
-            }
-        }
-    }
-    
-    private func deleteInterviewScript(at offsets: IndexSet) {
-        offsets.forEach { index in
-            viewModel.deleteScript(atIndex: index)
-        }
-    }
-}
+//struct InterviewScriptTestView: View {
+//    @StateObject var viewModel: InterviewViewModel
+//    @State private var newTitle = ""
+//    @State private var newContent = ""
+//    @State private var showEditInterviewScriptView = false
+//    @State private var editInterviewScriptIndex = 0
+//
+//    var body: some View {
+//        NavigationView {
+//            VStack {
+//                List {
+//                    ForEach(viewModel.interviewScriptModel.interviewScripts.indices, id: \.self) { index in
+//                        VStack(alignment: .leading, spacing: 8) {
+//                            Text(viewModel.interviewScriptModel.interviewScripts[index].title)
+//                                .font(.headline)
+//                            Text(viewModel.interviewScriptModel.interviewScripts[index].scriptContent)
+//                        }
+//                        .onTapGesture {
+//                            editInterviewScriptIndex = index
+//                            showEditInterviewScriptView.toggle()
+//                        }
+//                    }
+//                    .onDelete(perform: deleteInterviewScript)
+//                }
+//
+//                VStack(spacing: 12) {
+//                    TextField("Enter title", text: $newTitle)
+//                        .textFieldStyle(RoundedBorderTextFieldStyle())
+//                    TextField("Enter content", text: $newContent)
+//                        .textFieldStyle(RoundedBorderTextFieldStyle())
+//                    Button(action: {
+//                        viewModel.createScript(title: newTitle, content: newContent)
+//                        newTitle = ""
+//                        newContent = ""
+//                    }) {
+//                        Text("Add Interview Script")
+//                            .bold()
+//                            .foregroundColor(.white)
+//                            .padding()
+//                            .background(Color.blue)
+//                            .cornerRadius(8)
+//                    }
+//                }
+//                .padding()
+//
+//            }
+//            .navigationTitle("Interview Scripts")
+//            .sheet(isPresented: $showEditInterviewScriptView) {
+//                EditInterviewScriptTestView(viewModel: viewModel, index: editInterviewScriptIndex, updatedTitle: viewModel.interviewScriptModel.interviewScripts[editInterviewScriptIndex].title, updatedContent: viewModel.interviewScriptModel.interviewScripts[editInterviewScriptIndex].scriptContent)
+//            }
+//        }
+//    }
+//
+//    private func deleteInterviewScript(at offsets: IndexSet) {
+//        offsets.forEach { index in
+//            viewModel.deleteScript(atIndex: index)
+//        }
+//    }
+//}

--- a/Pressor/Pressor/Views/TestViews/MainTestView.swift
+++ b/Pressor/Pressor/Views/TestViews/MainTestView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MainTestView: View {
     
-    @ObservedObject var vm: VoiceViewModel = VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(scriptTitle: "", scriptContent: "")))
+    @ObservedObject var vm: VoiceViewModel = VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: "")))
     @State var isTapped: Bool = false
     @State var isSheetShowing: Bool = false
     @State var isShowingAlert = false
@@ -141,6 +141,6 @@ struct MainTestView: View {
 
 struct MainTestView_Previews: PreviewProvider {
     static var previews: some View {
-        MainTestView(vm: VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(scriptTitle: "", scriptContent: ""))))
+        MainTestView(vm: VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: ""))))
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
- Script UX 변경 및 인터뷰 : 대본 = 1 : n 구조에서 1 : 1 구조 변경으로 인한 Refactor

## 작업 사항
- [ScriptModel 구조 변경](https://github.com/DeveloperAcademy-POSTECH/MC2_2thCo.6thPlatoon/commit/0f96afc4c84eb7c4000ed2d91263a721e5748aac)
- [InterviewViewModel 구조 변경 및 스크립트 처리 간소화, VoiceViewModel 연동](https://github.com/DeveloperAcademy-POSTECH/MC2_2thCo.6thPlatoon/commit/80ea2fdefa53af11cd67213a02096193a5b51572)

- [Script 구조 변경에 따른 후속작업](https://github.com/DeveloperAcademy-POSTECH/MC2_2thCo.6thPlatoon/commit/4118bee058eba5a3a4894a3e7a0f5231bbc124ba)
- [Script 구조 변경에 따른 MainRecordView 수정, isShowingAlert 네이밍구체화](https://github.com/DeveloperAcademy-POSTECH/MC2_2thCo.6thPlatoon/commit/da366fc93529eaf91a21bf6d9894ee1ef94f69d0)
- [AudioVisualizerVIew 불필요한 Stack삭제](https://github.com/DeveloperAcademy-POSTECH/MC2_2thCo.6thPlatoon/commit/58074d97e2396363809f7e3f1f2e73d7ab9b5889)
- [Script 관련 TestView 주석처리(추후 삭제 예정)](https://github.com/DeveloperAcademy-POSTECH/MC2_2thCo.6thPlatoon/commit/2d87dd2abcd63d82464fe1d28e432b506ab06a8d)

## 주요 로직(Optional)
### 변경 후(InterviewViewModel)
```swift

class InterviewViewModel: ObservableObject {
    // Current script
    @Published var script: Script
    
    // VoiceViewModel
    var voiceViewModel: VoiceViewModel

    // Default initializer
    init(voiceViewModel: VoiceViewModel) {
        self.voiceViewModel = voiceViewModel
        self.script = Script(title: "", description: "")
    }
    
    // 대본 수정(추가, 삭제 - 공백으로 바꿀 경우)
    func setScript(title: String, description: String) {
        self.script = Script(title: title, description: description)
    }
    
    // 대본 가져오기
    func getScript() -> Script {
        return self.script
    }
}
```
### 변경 후(InterviewScriptModel)
```swift
struct Script {
    var title: String
    var description: String
}
```
