### PR TITLE
Feat/#58 implement interview recording script view

### DIFF
--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		608D9D7D2A01F673001E8E3C /* InterviewDetailTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608D9D7C2A01F673001E8E3C /* InterviewDetailTestView.swift */; };
 		608D9D7F2A022F5E001E8E3C /* MainTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608D9D7E2A022F5E001E8E3C /* MainTestView.swift */; };
 		60D579B02A0E17C60006D884 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D579AF2A0E17C60006D884 /* PermissionManager.swift */; };
+		60F0BC122A0E859600B6B539 /* InterviewRecordingScriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F0BC112A0E859600B6B539 /* InterviewRecordingScriptView.swift */; };
 		7E6E395D2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6E395C2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift */; };
 		7E6E395F2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6E395E2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift */; };
 		7E74F30B2A0CDB4700D03AF3 /* RoutingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E74F30A2A0CDB4700D03AF3 /* RoutingManager.swift */; };
@@ -54,6 +55,7 @@
 		608D9D7E2A022F5E001E8E3C /* MainTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTestView.swift; sourceTree = "<group>"; };
 		608D9D802A026014001E8E3C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		60D579AF2A0E17C60006D884 /* PermissionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
+		60F0BC112A0E859600B6B539 /* InterviewRecordingScriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewRecordingScriptView.swift; sourceTree = "<group>"; };
 		7E6E395C2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewDetailEditModalView.swift; sourceTree = "<group>"; };
 		7E6E395E2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewDetailChatEditModalView.swift; sourceTree = "<group>"; };
 		7E74F30A2A0CDB4700D03AF3 /* RoutingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingManager.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 				7E6E395B2A03A15C0073CDD0 /* InterviewModals */,
 				7EDEB0D42A011DF600176D72 /* MainInterviewList.swift */,
 				C957BB9E2A027D05006649A8 /* InterviewRecordingView.swift */,
+				60F0BC112A0E859600B6B539 /* InterviewRecordingScriptView.swift */,
 				AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */,
 			);
 			path = InterviewViews;
@@ -310,6 +313,7 @@
 				608D9D6C2A013AF0001E8E3C /* InterviewRecordingTestView.swift in Sources */,
 				7EDEB0D12A011DD100176D72 /* MainRecordView.swift in Sources */,
 				7EDEB0D32A011DE800176D72 /* AddRecordScriptModalView.swift in Sources */,
+				60F0BC122A0E859600B6B539 /* InterviewRecordingScriptView.swift in Sources */,
 				7EDEB0DB2A011E2A00176D72 /* RecordViewModel.swift in Sources */,
 				6072D0E72A0542E6005583FC /* InterviewRecordingEndTestView.swift in Sources */,
 				7EDEB0BD2A011B4B00176D72 /* PressorApp.swift in Sources */,

--- a/Pressor/Pressor/Resources/Extensions/Color+.swift
+++ b/Pressor/Pressor/Resources/Extensions/Color+.swift
@@ -49,7 +49,7 @@ extension Color {
         .init(hex: "FFA600")
     }
     static var BackgroundGray_Dark: Self {
-        .init(hex: "2C2C2E")
+        .init(hex: "1C1C1E")
     }
     static var BackgroundGray_Light: Self {
         .init(hex: "F2F2F7")

--- a/Pressor/Pressor/ViewModels/InterviewViewModel.swift
+++ b/Pressor/Pressor/ViewModels/InterviewViewModel.swift
@@ -10,25 +10,18 @@ import Foundation
 
 class InterviewViewModel: ObservableObject {
     // Current script
-    @Published var script: Script
-    
-    // VoiceViewModel
-    @Published var voiceViewModel: VoiceViewModel
-
-    // Default initializer
-    init(voiceViewModel: VoiceViewModel) {
-        self.voiceViewModel = voiceViewModel
-        self.script = Script(title: "", description: "")
-    }
+    @Published var script: Script?
     
     // 대본 수정(추가, 삭제 - 공백으로 바꿀 경우)
     func setScript(title: String, description: String) {
         self.script = Script(title: title, description: description)
-        voiceViewModel.interview.script = script
     }
     
     // 대본 가져오기
     func getScript() -> Script {
-        return self.script
+        guard let script = self.script else {
+            return Script(title: "", description: "")
+        }
+        return script
     }
 }

--- a/Pressor/Pressor/ViewModels/InterviewViewModel.swift
+++ b/Pressor/Pressor/ViewModels/InterviewViewModel.swift
@@ -13,7 +13,7 @@ class InterviewViewModel: ObservableObject {
     @Published var script: Script
     
     // VoiceViewModel
-    var voiceViewModel: VoiceViewModel
+    @Published var voiceViewModel: VoiceViewModel
 
     // Default initializer
     init(voiceViewModel: VoiceViewModel) {
@@ -24,6 +24,7 @@ class InterviewViewModel: ObservableObject {
     // 대본 수정(추가, 삭제 - 공백으로 바꿀 경우)
     func setScript(title: String, description: String) {
         self.script = Script(title: title, description: description)
+        voiceViewModel.interview.script = script
     }
     
     // 대본 가져오기

--- a/Pressor/Pressor/ViewModels/VoiceViewModel.swift
+++ b/Pressor/Pressor/ViewModels/VoiceViewModel.swift
@@ -33,10 +33,6 @@ class VoiceViewModel : NSObject, ObservableObject , AVAudioPlayerDelegate{
     public var date: Date = Date()
     private var playingURL : URL?
     
-    
-    // TODO: Script create
-    public var script: Script = Script(title: "", description: "")
-    
     init(interview: Interview){
         self.interview = interview
     }
@@ -66,7 +62,6 @@ class VoiceViewModel : NSObject, ObservableObject , AVAudioPlayerDelegate{
         }
         
         self.interview = interview
-        self.interview.script = self.script
         self.interviewPath = directoryPath
         
         // vm의 recording과 STT배열 초기화

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
@@ -1,0 +1,343 @@
+//
+//  InterviewRecordingScriptView.swift
+//  Pressor
+//
+//  Created by 홍승완 on 2023/05/12.
+//
+
+import SwiftUI
+
+struct InterviewRecordingScriptView: View {
+    @ObservedObject var vm: VoiceViewModel
+    
+    @State private var isShowingList = false
+    @State var transcriptIndex: Int = 0
+    @StateObject private var audioInputManager = AudioInputViewModel()
+    @State private var isRecording = false
+    @State private var isPaused = true
+    @State private var duration: TimeInterval = 0.0
+    @State private var speakerSwitch: Color = SpeakerSwitch.speakerOne
+    @State private var timer: Timer? = nil
+    @State private var visualColor: Color = Color.PressorOrange
+    @State private var isChevronAnimating = false
+    @State private var isShowingBottomImage = true
+    @State private var initChevronOffsetYValue = CGFloat.zero
+    @State private var isShowingTopImage = true
+    @Binding var isShownInterviewRecordingView: Bool
+    @State var isShowingCancelAlert = false
+    
+    
+    // 타이머 시간 포맷
+    func formattedDuration(_ duration: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = .pad
+        return formatter.string(from: duration) ?? "00:00"
+    }
+    
+    // 화자 구분 색상
+    private struct SpeakerSwitch {
+        static let speakerOne = Color.PressorOrange
+        static let speakerTwo = Color.PressorBlue
+    }
+    
+    // 타이머 시작 함수
+    private func startTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
+            duration += 0.1
+        }
+    }
+    
+    // 타이머 중지 함수
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    // 타이머 초기화 함수
+    private func resetDuration() {
+        duration = 0
+    }
+    
+    // 타이머 일시정지 함수
+    private func pauseResumeTimer() {
+        if timer == nil {
+            startTimer()
+        } else {
+            stopTimer()
+        }
+    }
+    var body: some View {
+        NavigationView{
+            ZStack {
+                VStack {
+                    HStack { // 컨트롤 영역 (일시정지 및 재생 + 완료)
+                        Button {
+                            self.isShowingCancelAlert.toggle()
+                        } label: {
+                            Text("취소")
+                                .foregroundColor(Color.red)
+                                .font(.headline)
+                        }
+                        .alert(isPresented: $isShowingCancelAlert) {
+                            Alert(
+                                title: Text("녹음 취소"),
+                                message: Text("진행중인 녹음이 삭제됩니다."),
+                                primaryButton: .destructive(Text("녹음 취소")) {
+                                    self.isShownInterviewRecordingView.toggle()
+                                },
+                                secondaryButton: .cancel(Text("되돌아가기"))
+                            )
+                        }
+                        .position(
+                            x: UIScreen.main.bounds.width / 6.5,
+                            y: UIScreen.main.bounds.height * 0.03
+                        )
+                        
+                        // 일시정지 및 재생 버튼 로직
+                        Button(action: {
+                            isRecording.toggle()
+                            if isRecording {
+                                // 녹음 중일때 -> 녹음 시작 및 타이머 시작
+                                isPaused = false
+                                audioInputManager.startRecording { buffer in
+                                    DispatchQueue.main.async { }
+                                }
+                                startTimer()
+                                // 녹음 중일때 or 일시정지일 떄 오디오 비주얼라이저 색상 변경
+                                if speakerSwitch == SpeakerSwitch.speakerOne {
+                                    visualColor = Color.PressorOrange
+                                } else {
+                                    visualColor = Color.PressorBlue
+                                }
+                                vm.startRecording()
+                            } else {
+                                // 일시정지일때 -> 타이머 정지 및 오디오 비주얼라이저 끔
+                                audioInputManager.stopRecording()
+                                isPaused = true
+                                stopTimer()
+                                // 오디오 비주얼라이저 회색으로 비활성화 표시
+                                visualColor = Color.gray
+                                
+                                // 일단 먼저 녹음중지하고 기록함
+                                vm.stopRecording(
+                                    index: self.transcriptIndex,
+                                    recoder: vm.recoderType
+                                )
+                                self.transcriptIndex += 1
+                            }
+                        }) {
+                            // 일시정지 및 재생 버튼 UI
+                            RoundedRectangle(cornerRadius: 35)
+                            // 버튼 겉 stroke
+                                .stroke(!isPaused ? Color.white : Color.red, lineWidth: 3)
+                                .frame(width: 131, height: 44)
+                            // 버튼 속 fill
+                                .overlay(RoundedRectangle(cornerRadius: 35)
+                                    .frame(width: 119, height: 32)
+                                         // 녹음 중일때 -> 검정색, 녹음 일시정지일때 -> 빨간색
+                                    .foregroundColor(!isPaused ? Color.black : Color.PressorRed_Dark)
+                                    .overlay(
+                                        HStack {
+                                            // 녹음 중일때 -> 일시정지 심볼, 녹음 일시정지일때 -> 재생 심볼
+                                            Image(systemName: !isPaused ? "pause.fill" : "play.fill")
+                                                .resizable()
+                                                .frame(width: 18, height: 18)
+                                                .foregroundColor(Color.red)
+                                            // 타이머 텍스트
+                                            Text(formattedDuration(duration))
+                                                .font(.title2)
+                                                .fontDesign(.rounded)
+                                                .fontWeight(.bold)
+                                                .foregroundColor(!isPaused ? Color.white : Color.red)
+                                                .frame(minWidth: 50)
+                                                .monospacedDigit()
+                                        }
+                                    )
+                                )
+                        }
+                        .position(
+                            x: UIScreen.main.bounds.width / 6.15,
+                            y: UIScreen.main.bounds.height * 0.03
+                        )
+                        .onAppear {
+                            vm.recoderType = Recorder.interviewer
+                            vm.startRecording()
+                            
+                            isRecording = true
+                            // 녹음 중일때 -> 녹음 시작 및 타이머 시작
+                            isPaused = false
+                            audioInputManager.startRecording { buffer in
+                                DispatchQueue.main.async {}
+                            }
+                            startTimer()
+                            // 녹음 중일때 or 일시정지일 떄 오디오 비주얼라이저 색상 변경
+                            if speakerSwitch == SpeakerSwitch.speakerOne {
+                                visualColor = Color.PressorOrange
+                            } else {
+                                visualColor = Color.PressorBlue
+                            }
+                        }
+                        
+                        // 완료 버튼 로직
+                        NavigationLink(
+                            destination: InterviewDetailEditModalView(vm: vm)
+                                .onTapGesture {
+                                    // 완료버튼 누를 때 interview 인스턴스를 업데이트
+                                    vm.interview.recordSTT = vm.transcripts
+                                    vm.interview.records = vm.recordings
+                                    vm.interview.details.playTime = formattedDuration(duration)
+                                },
+                            label: {
+                                Text("완료")
+                                    .font(.headline)
+                                // 녹음 중일때 -> 회색, 녹음 일시정지일때 -> 빨간색
+                                    .foregroundColor(!isPaused ? Color.BackgroundGray_Dark : Color.red)
+                                // 녹음 중일 때 완료 버튼 비활성화
+                                    .position(
+                                        x: UIScreen.main.bounds.width / 6,
+                                        y: UIScreen.main.bounds.height * 0.03
+                                    )
+                            } //label
+                        ) // NavigationLink
+                        .navigationTitle("뒤로")
+                        .navigationBarHidden(true)
+                        .disabled(isRecording)
+                    } // HStack
+                    // 화자 전환 기능
+                    RoundedRectangle(cornerRadius: 44)
+                        // 화자전환 영역
+                        .fill(Color.BackgroundGray_Dark)
+                        .frame(
+                            width: UIScreen.main.bounds.width * 0.93,
+                            height: UIScreen.main.bounds.height * 0.74
+                        )
+                        // 화자전환 제스처
+                        .gesture(
+                            DragGesture()
+                                .onEnded { value in
+                                    let isDraggingDownward = (value.translation.height > 100 && speakerSwitch == SpeakerSwitch.speakerTwo) || (value.translation.height < -100 && speakerSwitch == SpeakerSwitch.speakerOne)
+                                    withAnimation(.spring()) {
+                                        if isDraggingDownward {
+                                            // 오디오 비주얼라이저 색상
+                                            if speakerSwitch == SpeakerSwitch.speakerOne {
+                                                speakerSwitch = SpeakerSwitch.speakerTwo
+                                                visualColor = Color.PressorBlue
+                                                self.isChevronAnimating = true
+                                            } else {
+                                                speakerSwitch = SpeakerSwitch.speakerOne
+                                                visualColor = Color.PressorOrange
+                                                self.isChevronAnimating = false
+                                            }
+                                            
+                                            if vm.isRecording {
+                                                // 화자바꾸지 않고 기록함
+                                                vm.stopRecording(
+                                                    index: self.transcriptIndex,
+                                                    recoder: vm.recoderType
+                                                )
+                                                self.transcriptIndex += 1
+                                                // 화자를 바꾸기
+                                                if vm.recoderType == Recorder.interviewer { // 인터뷰어일때
+                                                    vm.recoderType = Recorder.interviewee // 화자 바꾸고
+                                                } else { // 인터뷰이일때
+                                                    vm.recoderType = Recorder.interviewer
+                                                }
+                                                vm.startRecording()
+                                            } else {
+                                                // 화자를 바꾸기
+                                                if vm.recoderType == Recorder.interviewer { // 인터뷰어일때
+                                                    vm.recoderType = Recorder.interviewee // 화자 바꾸고
+                                                } else { // 인터뷰이일때
+                                                    vm.recoderType = Recorder.interviewer
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                        )
+                        // 화자전환 제스처 가이드
+                        .overlay {
+                            Group {
+                                if speakerSwitch == SpeakerSwitch.speakerOne {
+                                    // 내가 화자일때
+                                    if isShowingBottomImage {
+                                        VStack(spacing: 20) {
+                                            Image(systemName: "chevron.compact.up")
+                                                .resizable()
+                                                .frame(width: 34, height: 10)
+                                                .foregroundColor(Color.PressorOrange)
+                                                .offset(x: 0, y: isChevronAnimating ? initChevronOffsetYValue - 15 : initChevronOffsetYValue)
+                                                .animation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true), value: isChevronAnimating)
+                                                .onAppear {
+                                                    self.isChevronAnimating = true
+                                                }
+                                            Text("쓸어올려 상대로 전환")
+                                                .foregroundColor(Color.PressorOrange)
+                                        }
+                                        .padding(.top, UIScreen.main.bounds.height / 2)
+                                        .onAppear {
+                                        }
+                                    }
+                                } else {
+                                    // 상대가 화자일때
+                                    if isShowingBottomImage {
+                                        VStack(spacing: 20) {
+                                            Text("쓸어내려 나로 전환")
+                                                .foregroundColor(Color.PressorBlue)
+                                            Image(systemName: "chevron.compact.down")
+                                                .resizable()
+                                                .frame(width: 34, height: 10)
+                                                .foregroundColor(Color.PressorBlue)
+                                                .offset(x: 0, y: !isChevronAnimating ? 15 + initChevronOffsetYValue : initChevronOffsetYValue)
+                                                .animation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true), value: !isChevronAnimating)
+                                                .onAppear {
+                                                    self.isChevronAnimating = false
+                                                }
+                                        }
+                                        .padding(.bottom, UIScreen.main.bounds.height / 2)
+                                        .onAppear {
+                                        }
+                                    }
+                                }
+                            }
+                            .font(.headline)
+                            .fontWeight(.bold)
+                        }
+                        .position(
+                            x: UIScreen.main.bounds.width / 2,
+                            y: UIScreen.main.bounds.height * 0.006
+                        )
+                } // VStack
+                // 오디오 비쥬얼라이저 뷰
+                AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording, isPaused: $isPaused, audioVisualizerColor: $visualColor)
+                    .position(x: UIScreen.main.bounds.width / 2, y: UIScreen.main.bounds.height * 0.875)
+            } // ZStack
+            .frame(
+                maxWidth: .infinity,
+                maxHeight: .infinity
+            )// 컨트롤영역 + 화자전환영역 + 오디오 비주얼라이저 VStack 닫기
+            .background (
+                Color.black
+            )
+            .onAppear {
+                audioInputManager.prepare()
+            }
+            .onDisappear {
+                audioInputManager.stopRecording()
+            }
+        } // NavigationView
+        .accentColor(Color.red)
+    } // body
+} // struct
+
+struct InterviewRecordingScriptView_Previews: PreviewProvider {
+    static var previews: some View {
+        InterviewRecordingScriptView(
+            vm: VoiceViewModel(
+                interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: Script(title: "", description: "")))
+            , isShownInterviewRecordingView: .constant(false)
+        )
+    }
+}

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
@@ -44,8 +44,8 @@ struct InterviewRecordingScriptView: View {
     
     // 타이머 시작 함수
     private func startTimer() {
-        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
-            duration += 0.1
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            duration += 1
         }
     }
     

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
@@ -208,7 +208,7 @@ struct InterviewRecordingScriptView: View {
                     ZStack {
                         ScrollView(.vertical, showsIndicators: false) {
                             VStack(alignment: .leading, spacing: 0) {
-                                Text("\n\(vm.interview.script.description)")
+                                Text("\n\n\(vm.interview.script.description)\n\n")
                                     .font(.system(size: 22))
                                     .foregroundColor(.white)
                             }

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
@@ -205,13 +205,40 @@ struct InterviewRecordingScriptView: View {
                         .navigationBarHidden(true)
                         .disabled(isRecording)
                     } // HStack
+                    ZStack {
+                        ScrollView(.vertical, showsIndicators: false) {
+                            VStack(alignment: .leading, spacing: 0) {
+                                Text("\n\(vm.interview.script.description)")
+                                    .font(.system(size: 22))
+                                    .foregroundColor(.white)
+                            }
+                        }
+                        .frame(height: UIScreen.main.bounds.height * 0.31)
+                        .padding()
+                        VStack {
+                            Rectangle()
+                                .frame(height: 5)
+                                .background(.black)
+                                .shadow(color: .black, radius: 3, x: 0, y: 3)
+                                .shadow(color: .black, radius: 5, x: 0, y: 3)
+                                .shadow(color: .black, radius: 7, x: 0, y: 3)
+                            Spacer()
+                            Rectangle()
+                                .frame(height: 5)
+                                .background(.black)
+                            .shadow(color: .black, radius: 3, x: 0, y: -3)
+                            .shadow(color: .black, radius: 5, x: 0, y: -3)
+                            .shadow(color: .black, radius: 7, x: 0, y: -3)
+                        }
+                        .frame(height: UIScreen.main.bounds.height * 0.31)
+                    }
                     // 화자 전환 기능
                     RoundedRectangle(cornerRadius: 44)
                         // 화자전환 영역
                         .fill(Color.BackgroundGray_Dark)
                         .frame(
                             width: UIScreen.main.bounds.width * 0.93,
-                            height: UIScreen.main.bounds.height * 0.74
+                            height: UIScreen.main.bounds.height * 0.42
                         )
                         // 화자전환 제스처
                         .gesture(
@@ -276,7 +303,7 @@ struct InterviewRecordingScriptView: View {
                                             Text("쓸어올려 상대로 전환")
                                                 .foregroundColor(Color.PressorOrange)
                                         }
-                                        .padding(.top, UIScreen.main.bounds.height / 2)
+                                        .padding(.top, UIScreen.main.bounds.height / 4)
                                         .onAppear {
                                         }
                                     }
@@ -296,7 +323,7 @@ struct InterviewRecordingScriptView: View {
                                                     self.isChevronAnimating = false
                                                 }
                                         }
-                                        .padding(.bottom, UIScreen.main.bounds.height / 2)
+                                        .padding(.bottom, UIScreen.main.bounds.height / 4)
                                         .onAppear {
                                         }
                                     }
@@ -305,10 +332,7 @@ struct InterviewRecordingScriptView: View {
                             .font(.headline)
                             .fontWeight(.bold)
                         }
-                        .position(
-                            x: UIScreen.main.bounds.width / 2,
-                            y: UIScreen.main.bounds.height * 0.006
-                        )
+                        .padding(.bottom, UIScreen.main.bounds.height * 0.065)
                 } // VStack
                 // 오디오 비쥬얼라이저 뷰
                 AudioVisualizerView(audioInputManager: audioInputManager, isRecording: $isRecording, isPaused: $isPaused, audioVisualizerColor: $visualColor)

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -44,8 +44,8 @@ struct InterviewRecordingView: View {
     
     // 타이머 시작 함수
     private func startTimer() {
-        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
-            duration += 0.1
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            duration += 1
         }
     }
     

--- a/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
+++ b/Pressor/Pressor/Views/RecordViews/AddScriptModalView.swift
@@ -18,7 +18,6 @@ struct AddScriptModalView: View {
     @Environment(\.presentationMode) private var presentationMode
     
     @ObservedObject var interviewViewModel: InterviewViewModel
-    @ObservedObject var voiceViewModel: VoiceViewModel
     // 외부에서 전달된 scriptAdded를 바인딩하여 완료 버튼을 눌렀을 때 업데이트
     @Binding var scriptAdded: Bool
     
@@ -29,9 +28,8 @@ struct AddScriptModalView: View {
     let mode: ScriptMode
     
     // 초기화 메서드
-    init(interviewViewModel: InterviewViewModel, voiceViewModel: VoiceViewModel, scriptAdded: Binding<Bool>, title: String, description: String, mode: ScriptMode) {
+    init(interviewViewModel: InterviewViewModel, scriptAdded: Binding<Bool>, title: String, description: String, mode: ScriptMode) {
         self.interviewViewModel = interviewViewModel
-        self.voiceViewModel = voiceViewModel
         _scriptAdded = scriptAdded
         _title = State(initialValue: title)
         _description = State(initialValue: description)
@@ -96,7 +94,6 @@ struct AddScriptModalView: View {
                     interviewViewModel.setScript(title: title, description: description)
                 case .edit:
                     interviewViewModel.setScript(title: title, description: description)
-                    voiceViewModel.script = interviewViewModel.getScript()
                 }
                 // 제목과 본문을 입력한 경우, scriptAdded를 true로 설정하고 모달 창 종료
                 scriptAdded = true

--- a/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
+++ b/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
@@ -47,7 +47,7 @@ struct MainRecordView: View {
                         VStack {
                             // MARK: - Mic Button
                             Button {
-                                
+                                print(vm.interview.script.description)
                                 if !isTimerCounting {
                                     countSec = 3
                                     isTimerCounting.toggle()
@@ -67,12 +67,13 @@ struct MainRecordView: View {
                                     .padding(.bottom, 40)
                             }
                             .fullScreenCover(isPresented: $isShownInterviewRecordingView) {
-                                InterviewRecordingView(vm: vm, isShownInterviewRecordingView: $isShownInterviewRecordingView)
+                                if scriptAdded {
+                                    InterviewRecordingScriptView(vm: vm, isShownInterviewRecordingView: $isShownInterviewRecordingView)
+                                } else {
+                                    InterviewRecordingView(vm: vm, isShownInterviewRecordingView: $isShownInterviewRecordingView)
+                                }
+                                
                             }
-                            .simultaneousGesture(TapGesture().onEnded{
-                                vm.initInterview()
-                                print(vm.interview)
-                            })
                         }
                         
                         VStack {

--- a/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
+++ b/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
@@ -56,6 +56,10 @@ struct MainRecordView: View {
                                         self.countSec -= 1
                                         if(countSec == 0){
                                             timerCount?.invalidate()
+                                            // MARK: 대본이 있다면 추가시키는 로직
+                                            if let scriptData = interviewViewModel?.getScript() {
+                                                vm.interview.script = scriptData
+                                            }
                                             self.isShownInterviewRecordingView.toggle()
                                             isTimerCounting.toggle()
                                         }
@@ -178,7 +182,7 @@ struct MainRecordView: View {
                 )
                 .disabled(isTimerCounting)
                 .sheet(isPresented: $showModal) {
-                    AddScriptModalView(interviewViewModel: interviewViewModel ?? InterviewViewModel(voiceViewModel: vm), voiceViewModel: vm, scriptAdded: $scriptAdded, title: scriptTitle, description: scriptDescription, mode: scriptAdded ? .edit : .add)
+                    AddScriptModalView(interviewViewModel: interviewViewModel ?? InterviewViewModel(), scriptAdded: $scriptAdded, title: scriptTitle, description: scriptDescription, mode: scriptAdded ? .edit : .add)
                 }
             }
             .tag(Constants.RECORD_TAB_ID)
@@ -187,8 +191,9 @@ struct MainRecordView: View {
                 Text("녹음")
             }
             .onAppear {
+                // MARK: VoiceViewModel과 interviewViewModel을 init합니다.
                 vm.initInterview()
-                interviewViewModel = InterviewViewModel(voiceViewModel: vm)
+                interviewViewModel = InterviewViewModel()
             }
             
             InterviewListView()

--- a/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
+++ b/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
@@ -11,7 +11,7 @@ struct MainRecordView: View {
     @Environment(\.presentationMode) private var presentationMode
     @EnvironmentObject var routingManager: RoutingManager
     @ObservedObject var vm: VoiceViewModel = VoiceViewModel(interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: "")))
-    @State private var interviewViewModel: InterviewViewModel? = nil
+    @State private var interviewViewModel: InterviewViewModel = InterviewViewModel()
     @State var isSheetShowing: Bool = false
     @State var isShowingScriptDeleteAlert = false
     @State var showModal = false
@@ -57,9 +57,7 @@ struct MainRecordView: View {
                                         if(countSec == 0){
                                             timerCount?.invalidate()
                                             // MARK: 대본이 있다면 추가시키는 로직
-                                            if let scriptData = interviewViewModel?.getScript() {
-                                                vm.interview.script = scriptData
-                                            }
+                                            vm.interview.script = interviewViewModel.getScript()
                                             self.isShownInterviewRecordingView.toggle()
                                             isTimerCounting.toggle()
                                         }
@@ -111,8 +109,8 @@ struct MainRecordView: View {
                                         
                                         Button("대본 수정", role: .destructive) {
                                             showModal = true
-                                            scriptTitle = interviewViewModel?.getScript().title ?? ""
-                                            scriptDescription = interviewViewModel?.getScript().description ?? ""
+                                            scriptTitle = interviewViewModel.getScript().title
+                                            scriptDescription = interviewViewModel.getScript().description
                                         }
                                         .sheet(isPresented: $showModal) {
                                                                                         
@@ -127,7 +125,7 @@ struct MainRecordView: View {
                                             title: Text("대본 삭제"),
                                             message: Text("정말로 이 대본을 삭제하시겠습니까?"),
                                             primaryButton: .destructive(Text("삭제")) {
-                                                interviewViewModel?.setScript(title: "", description: "")
+                                                interviewViewModel.setScript(title: "", description: "")
                                                 scriptAdded = false
                                             },
                                             secondaryButton: .cancel(Text("취소"))
@@ -182,7 +180,7 @@ struct MainRecordView: View {
                 )
                 .disabled(isTimerCounting)
                 .sheet(isPresented: $showModal) {
-                    AddScriptModalView(interviewViewModel: interviewViewModel ?? InterviewViewModel(), scriptAdded: $scriptAdded, title: scriptTitle, description: scriptDescription, mode: scriptAdded ? .edit : .add)
+                    AddScriptModalView(interviewViewModel: interviewViewModel, scriptAdded: $scriptAdded, title: scriptTitle, description: scriptDescription, mode: scriptAdded ? .edit : .add)
                 }
             }
             .tag(Constants.RECORD_TAB_ID)
@@ -193,7 +191,6 @@ struct MainRecordView: View {
             .onAppear {
                 // MARK: VoiceViewModel과 interviewViewModel을 init합니다.
                 vm.initInterview()
-                interviewViewModel = InterviewViewModel()
             }
             
             InterviewListView()


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
관련 이슈: #58

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
-  InterviewRecordingScriptView 구현
    - InterviewRecordingView를 복제하여 수정하여 구현하였습니다.
- MainRecordView에서 InterviewRecordingScriptView 연동
- InterviewViewModel의 setScript 메소드가 VoiceViewModel의 interview 인스턴스에 접근하여 script를 저장하고 있지 않는 버그 수정
- Color+ extension의 BackgroundGray_Dark 의 hex값을 더 어둡게 수정함 (같이 있던 모카의 요청)
- InterviewRecording(Script)View의 취소버튼 AlertModal의 버튼이 잘 눌리지 않는 버그를 수정해야 함

**추가**
- 다른 탭으로 이동후 다시 돌아왔을 시 onAppear에서 InterviewViewModel이 초기화됨에 따라 VoiceViewModel의 interview.script또한 초기화 되던 이슈를 해결하였습니다.

## 주요 로직(Optional)

### InterviewRecordingView &  InterviewRecordingScriptView
- withTimeInterval 갱신이 너무 빨라서 User Interaction이 무시되고 있던 이슈였습니다.
```diff
 private func startTimer() {
-        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-            duration += 0.1
+            duration += 1
    }
}
```

## 주요 로직(Optional)

### InterviewViewModel
- 첼란 코멘트에 따라 VoiceViewModel 참조를 제거하였습니다.
```swift
class InterviewViewModel: ObservableObject {
    // Current script
    @Published var script: Script?
    
    // 대본 수정(추가, 삭제 - 공백으로 바꿀 경우)
    func setScript(title: String, description: String) {
        self.script = Script(title: title, description: description)
    }
    
    // 대본 가져오기
    func getScript() -> Script {
        guard let script = self.script else {
            return Script(title: "", description: "")
        }
        return script
    }
}
```

### AddScriptModalView
- VoiceViewModel에 직접 할당하지 않게 되므로 해당 뷰에서 VoiceViewModel 관련 코드를 삭제하였습니다.

### MainRecordView
- onApeear시 InterviewViewModel을 init하는 코드를 삭제하였습니다.
- VoiceViewModel의 interview.script에 InterviewViewModel의 getScript()를 사용하여 할당하는 코드를 추가하였습니다.

