### PR TITLE
Fix/#60 main record view navigation bar item disable

### DIFF
--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
@@ -244,7 +244,7 @@ struct InterviewRecordingScriptView: View {
                         .gesture(
                             DragGesture()
                                 .onEnded { value in
-                                    let isDraggingDownward = (value.translation.height > 100 && speakerSwitch == SpeakerSwitch.speakerTwo) || (value.translation.height < -100 && speakerSwitch == SpeakerSwitch.speakerOne)
+                                    let isDraggingDownward = (value.translation.height > 50 && speakerSwitch == SpeakerSwitch.speakerTwo) || (value.translation.height < -50 && speakerSwitch == SpeakerSwitch.speakerOne)
                                     withAnimation(.spring()) {
                                         if isDraggingDownward {
                                             // 오디오 비주얼라이저 색상

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -217,7 +217,7 @@ struct InterviewRecordingView: View {
                         .gesture(
                             DragGesture()
                                 .onEnded { value in
-                                    let isDraggingDownward = (value.translation.height > 100 && speakerSwitch == SpeakerSwitch.speakerTwo) || (value.translation.height < -100 && speakerSwitch == SpeakerSwitch.speakerOne)
+                                    let isDraggingDownward = (value.translation.height > 50 && speakerSwitch == SpeakerSwitch.speakerTwo) || (value.translation.height < -50 && speakerSwitch == SpeakerSwitch.speakerOne)
                                     withAnimation(.spring()) {
                                         if isDraggingDownward {
                                             // 오디오 비주얼라이저 색상

--- a/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
+++ b/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
@@ -144,11 +144,24 @@ struct MainRecordView: View {
                                             .foregroundColor(Color.accentColor)
                                             .fontWeight(.semibold)
                                     }
+                                    .disabled(isTimerCounting)
                                 }
                             }
                         }
                     }
-                    if countSec != 0 {
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            NavigationLink {
+                                Text("세팅뷰")
+                            } label: {
+                                Image(systemName: "gearshape.fill")
+                                    .foregroundColor(.DisabledGary)
+                            }
+                        }
+                    }
+                    .disabled(isTimerCounting)
+                    
+                    if isTimerCounting {
                         ZStack{
                             RoundedRectangle(cornerRadius: 10)
                                 .fill(Color.white)
@@ -172,13 +185,6 @@ struct MainRecordView: View {
                         }
                     }
                 }
-                .navigationBarItems(trailing: NavigationLink(
-                    destination: Text("세팅뷰")) {
-                        Image(systemName: "gearshape.fill")
-                            .foregroundColor(.DisabledGary)
-                    }
-                )
-                .disabled(isTimerCounting)
                 .sheet(isPresented: $showModal) {
                     AddScriptModalView(interviewViewModel: interviewViewModel, scriptAdded: $scriptAdded, title: scriptTitle, description: scriptDescription, mode: scriptAdded ? .edit : .add)
                 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
관련이슈: #60 

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- MainRecordView의 녹음시작 취소 User interaction이 무시되는 이슈 수정
- InterviewRecordingView와 InterviewRecordingScriptView의 화자전환 드래그 제스처의 최소 upward, downward의 값을 100 -> 50으로 수정

