### PR TITLE
Feat/#71 implement interview list view

### DIFF
--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		60D01A322A120EDC00CE3E0A /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D01A312A120EDC00CE3E0A /* UserDefaults+.swift */; };
 		60D579B02A0E17C60006D884 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D579AF2A0E17C60006D884 /* PermissionManager.swift */; };
 		60F0BC122A0E859600B6B539 /* InterviewRecordingScriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F0BC112A0E859600B6B539 /* InterviewRecordingScriptView.swift */; };
+		7E3286102A121524005843C7 /* InterviewListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E32860F2A121524005843C7 /* InterviewListViewModel.swift */; };
+		7E3286122A125888005843C7 /* Array+AppStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3286112A125888005843C7 /* Array+AppStorage.swift */; };
 		7E392C792A0E092A00130338 /* InterviewBubbleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E392C782A0E092A00130338 /* InterviewBubbleManager.swift */; };
 		7E392C7B2A0E283C00130338 /* Array+SafeIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E392C7A2A0E283C00130338 /* Array+SafeIndex.swift */; };
 		7E3B3E5A2A0A0D6700DCA93A /* InterviewDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3B3E592A0A0D6700DCA93A /* InterviewDetailView.swift */; };
@@ -66,6 +68,8 @@
 		60D01A312A120EDC00CE3E0A /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		60D579AF2A0E17C60006D884 /* PermissionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
 		60F0BC112A0E859600B6B539 /* InterviewRecordingScriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewRecordingScriptView.swift; sourceTree = "<group>"; };
+		7E32860F2A121524005843C7 /* InterviewListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewListViewModel.swift; sourceTree = "<group>"; };
+		7E3286112A125888005843C7 /* Array+AppStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+AppStorage.swift"; sourceTree = "<group>"; };
 		7E392C782A0E092A00130338 /* InterviewBubbleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewBubbleManager.swift; sourceTree = "<group>"; };
 		7E392C7A2A0E283C00130338 /* Array+SafeIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeIndex.swift"; sourceTree = "<group>"; };
 		7E3B3E592A0A0D6700DCA93A /* InterviewDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewDetailView.swift; sourceTree = "<group>"; };
@@ -143,6 +147,7 @@
 				601CCC4C2A08D53F005B02C7 /* Date+.swift */,
 				7EC9A2972A0A398A004D14A1 /* BlurBackground.swift */,
 				7E392C7A2A0E283C00130338 /* Array+SafeIndex.swift */,
+				7E3286112A125888005843C7 /* Array+AppStorage.swift */,
 				60D01A312A120EDC00CE3E0A /* UserDefaults+.swift */,
 			);
 			path = Extensions;
@@ -208,6 +213,7 @@
 				7E74F30A2A0CDB4700D03AF3 /* RoutingManager.swift */,
 				7E392C782A0E092A00130338 /* InterviewBubbleManager.swift */,
 				60D579AF2A0E17C60006D884 /* PermissionManager.swift */,
+				7E32860F2A121524005843C7 /* InterviewListViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -339,6 +345,7 @@
 				608D9D7F2A022F5E001E8E3C /* MainTestView.swift in Sources */,
 				C918E6E02A09CC720074BAF0 /* AddScriptModalView.swift in Sources */,
 				608D9D6C2A013AF0001E8E3C /* InterviewRecordingTestView.swift in Sources */,
+				7E3286122A125888005843C7 /* Array+AppStorage.swift in Sources */,
 				7EC9A2982A0A398A004D14A1 /* BlurBackground.swift in Sources */,
 				7EDEB0D12A011DD100176D72 /* MainRecordView.swift in Sources */,
 				7EDEB0D32A011DE800176D72 /* AddRecordScriptModalView.swift in Sources */,
@@ -375,6 +382,7 @@
 				60D579B02A0E17C60006D884 /* PermissionManager.swift in Sources */,
 				60D01A322A120EDC00CE3E0A /* UserDefaults+.swift in Sources */,
 				7EDEB0D52A011DF600176D72 /* MainInterviewList.swift in Sources */,
+				7E3286102A121524005843C7 /* InterviewListViewModel.swift in Sources */,
 				6072D0E52A053E93005583FC /* Interview.swift in Sources */,
 				601CCC4D2A08D53F005B02C7 /* Date+.swift in Sources */,
 				C91E4D3B2A0B746300E5F983 /* InterviewScriptModel.swift in Sources */,

--- a/Pressor/Pressor/Models/Interview.swift
+++ b/Pressor/Pressor/Models/Interview.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct Interview: Identifiable, Codable {
-    let id: String = UUID().uuidString
+    var id: String = UUID().uuidString
     var details: InterviewDetail
     var records: [Record]
     var recordSTT: [String]
@@ -16,5 +16,9 @@ struct Interview: Identifiable, Codable {
     
     static func getDummyInterview() -> Self {
         Interview(details: InterviewDetail(interviewTitle: "123", userName: "123", userEmail: "asd", userPhoneNumber: "asd", date: Date(), playTime: "45"), records: [], recordSTT: [], script: .init(title: "title", description: "4543543543435"))
+    }
+    
+    static func getInitInterview() -> Self {
+        Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: ""))
     }
 }

--- a/Pressor/Pressor/Models/Record.swift
+++ b/Pressor/Pressor/Models/Record.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct Record: Codable {
-    let id: String = UUID().uuidString
+    var id: String = UUID().uuidString
     var fileURL : URL
     var createdAt : Date
     var type: String

--- a/Pressor/Pressor/PressorApp.swift
+++ b/Pressor/Pressor/PressorApp.swift
@@ -9,14 +9,16 @@ import SwiftUI
 
 @main
 struct PressorApp: App {
-    @ObservedObject var routeManager: RoutingManager = .init()
-    @ObservedObject var voiceViewModel: VoiceViewModel = .init(interview: .getDummyInterview())
+    @StateObject var routeManager: RoutingManager = .init()
+    @StateObject var voiceViewModel: VoiceViewModel = .init(interview: .getDummyInterview())
+    @StateObject var interviewListViewModel: InterviewListViewModel = .init()
     @ObservedObject var permissionManager: PermissionManager = .init()
     
     var body: some Scene {
         WindowGroup {
             MainRecordView(vm: voiceViewModel)
                 .environmentObject(routeManager)
+                .environmentObject(interviewListViewModel)
                 .onAppear {
                     permissionManager.requestAudioPermission()
                     permissionManager.requestRecordingPermission()

--- a/Pressor/Pressor/Resources/Constants.swift
+++ b/Pressor/Pressor/Resources/Constants.swift
@@ -11,4 +11,5 @@ enum Constants {
     static let NO_NAME_INTERVIEW: String = "이름 없는 인터뷰"
     static let RECORD_TAB_ID: String = "recordViewTab"
     static let INTERVIEW_TAB_ID: String = "interviewViewTab"
+    static let USERDEFAULTS_INTERVIEWS_KEY: String = "Interviews"
 }

--- a/Pressor/Pressor/Resources/Extensions/Array+AppStorage.swift
+++ b/Pressor/Pressor/Resources/Extensions/Array+AppStorage.swift
@@ -1,0 +1,28 @@
+//
+//  Array+AppStroage.swift
+//  Pressor
+//
+//  Created by Celan on 2023/05/15.
+//
+
+import Foundation
+
+extension Array: RawRepresentable where Element: Codable {
+    public init?(rawValue: String) {
+        guard
+            let data = rawValue.data(using: .utf8),
+            let result = try? JSONDecoder().decode([Element].self, from: data) else {
+            return nil
+        }
+        self = result
+    }
+    
+    public var rawValue: String {
+        guard
+            let data = try? JSONEncoder().encode(self),
+            let result = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return result
+    }
+}

--- a/Pressor/Pressor/Resources/Extensions/Color+.swift
+++ b/Pressor/Pressor/Resources/Extensions/Color+.swift
@@ -65,6 +65,10 @@ extension Color {
         .init(hex: "F2F2F7")
     }
     
+    static var pressorSystemGray_dark: Self {
+        .init(hex: "#C7C7CC")
+    }
+    
     static var pressorButtonBluePrimary: Self {
         .init(hex: "00C7BE")
     }

--- a/Pressor/Pressor/Resources/RecordBubble.swift
+++ b/Pressor/Pressor/Resources/RecordBubble.swift
@@ -8,18 +8,15 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-/**
- 인터뷰의 내용과 음성 컨트롤러를 담는 레코드 버블 입니다.
- 해당 뷰는 반드시 "스크롤뷰 내부"에서 호출합니다.
- 
- - Author: Celan
- */
 struct RecordBubble: View {
+    @EnvironmentObject var interviewListViewModel: InterviewListViewModel
     @StateObject var bubbleManager: InterviewBubbleManager
     @State var record: Record
     @State private var text: String = ""
     @State private var isReadyToPlay: Bool = true
     @State private var isEditing: Bool = false
+
+    let idx: Int
 
     var isInterviewerSpeaking: Bool {
         record.type == Recorder.interviewer.rawValue
@@ -28,14 +25,17 @@ struct RecordBubble: View {
     // MARK: - body
     var body: some View {
         HStack(spacing: 10) {
-            if isInterviewerSpeaking {
-                playButtonBuilder(with: bubbleManager.currentInterview)
-                
-                recordBubbleBuilder(with: bubbleManager.currentInterview)
-            } else {
-                recordBubbleBuilder(with: bubbleManager.currentInterview)
+            if
+                let interviewList = interviewListViewModel.interviewList[safe: idx] {
+                if isInterviewerSpeaking {
+                    playButtonBuilder(with: interviewList)
 
-                playButtonBuilder(with: bubbleManager.currentInterview)
+                    recordBubbleBuilder(with: interviewList)
+                } else {
+                    recordBubbleBuilder(with: interviewList)
+
+                    playButtonBuilder(with: interviewList)
+                }
             }
         }
         .padding(
@@ -49,7 +49,8 @@ struct RecordBubble: View {
             InterviewDetailChatEditModalView(
                 interviewBubbleManager: bubbleManager,
                 isInterviewDetailChatEditModalViewDisplayed: $isEditing,
-                transcriptIndex: record.transcriptIndex
+                transcriptIndex: record.transcriptIndex,
+                interviewIdx: idx
             )
         }
     }

--- a/Pressor/Pressor/ViewModels/InterviewBubbleManager.swift
+++ b/Pressor/Pressor/ViewModels/InterviewBubbleManager.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import AVFoundation
 
 final class InterviewBubbleManager: NSObject, ObservableObject, AVAudioPlayerDelegate {
-    @Published var currentInterview: Interview = .getDummyInterview()
     @Published var duration: Double = 0.0
     @Published var formattedDuration: String = ""
     @Published var progress: CGFloat = 0.0
@@ -18,13 +17,6 @@ final class InterviewBubbleManager: NSObject, ObservableObject, AVAudioPlayerDel
     
     private var formatter = DateComponentsFormatter()
     private var audioPlayer: AVAudioPlayer = .init()
-    
-    // MARK: LIFECYCLE
-    init(
-        currentInterview: Interview
-    ) {
-        super.init()
-    }
     
     private func prepareAudioPlayer(with audioPlayer: AVAudioPlayer) {
         formatter.allowedUnits = [.minute, .second]
@@ -80,32 +72,5 @@ final class InterviewBubbleManager: NSObject, ObservableObject, AVAudioPlayerDel
         } else {
             print("NOT SUCCESS: \(flag.description)")
         }
-    }
-}
-
-// MARK: - Interview Edit & Update
-extension InterviewBubbleManager {
-    public func updateState(
-        interviewTitle: inout String,
-        userName: inout String,
-        userEmail: inout String,
-        userPhoneNumber: inout String
-    ) {
-        interviewTitle = currentInterview.details.interviewTitle
-        userName = currentInterview.details.userName
-        userEmail = currentInterview.details.userEmail
-        userPhoneNumber = currentInterview.details.userPhoneNumber
-    }
-    
-    public func updateInterviewDetails(
-        interviewTitle: String,
-        userName: String,
-        userEmail: String,
-        userPhoneNumber: String
-    ) {
-        currentInterview.details.interviewTitle = interviewTitle
-        currentInterview.details.userName = userName
-        currentInterview.details.userEmail = userEmail
-        currentInterview.details.userPhoneNumber = userPhoneNumber
     }
 }

--- a/Pressor/Pressor/ViewModels/InterviewListViewModel.swift
+++ b/Pressor/Pressor/ViewModels/InterviewListViewModel.swift
@@ -1,0 +1,16 @@
+//
+//  InterviewListViewModel.swift
+//  Pressor
+//
+//  Created by Celan on 2023/05/15.
+//
+
+import SwiftUI
+
+final class InterviewListViewModel: ObservableObject {
+    @AppStorage(Constants.USERDEFAULTS_INTERVIEWS_KEY) var interviewList: [Interview] = []
+    
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+    
+}

--- a/Pressor/Pressor/ViewModels/InterviewListViewModel.swift
+++ b/Pressor/Pressor/ViewModels/InterviewListViewModel.swift
@@ -9,8 +9,29 @@ import SwiftUI
 
 final class InterviewListViewModel: ObservableObject {
     @AppStorage(Constants.USERDEFAULTS_INTERVIEWS_KEY) var interviewList: [Interview] = []
+    @Published var currentInterview: Interview = .getDummyInterview()
     
-    private let decoder = JSONDecoder()
-    private let encoder = JSONEncoder()
+    public func getEachInterview(idx: Int) -> Interview? {
+        if interviewList.count > 0 {
+            return self.interviewList[idx]
+        } else {
+            return nil
+        }
+    }
     
+    public func getEachInterviewDetail(idx: Int) -> InterviewDetail? {
+        if interviewList.count > 0 {
+            return self.interviewList[idx].details
+        } else {
+            return nil
+        }
+    }
+    
+    public func getEachInterviewRecordList(idx: Int) -> [Record]? {
+        if interviewList.count > 0 {
+            return self.interviewList[idx].records
+        } else {
+            return nil
+        }
+    }
 }

--- a/Pressor/Pressor/ViewModels/RoutingManager.swift
+++ b/Pressor/Pressor/ViewModels/RoutingManager.swift
@@ -9,4 +9,5 @@ import SwiftUI
 
 final class RoutingManager: ObservableObject {
     @Published var currentTab: String = Constants.RECORD_TAB_ID
+    @Published var isRecordViewDisplayed: Bool = false
 }

--- a/Pressor/Pressor/Views/InterviewViews/InterviewListView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewListView.swift
@@ -3,182 +3,87 @@
 //  Pressor
 //
 //  Created by sup on 2023/05/03.
-//
+//  Refactored by Celan on 2023/05/15.
 
 import SwiftUI
 
-//MARK: - interview에서 해당 구조체가 넘어온다고 가정
-// TODO: - 추후에 실제 데이터로 바꿔요
-struct dummyDataa {
-    let id = UUID().uuidString
-    let title: String
-    let date : Date!
-    let interviewTime: String
-}
-
-
 struct InterviewListView: View {
-
-
-    // 위의 Todo의 실제데이터가 들어올 내용이 items입니다.
-    @State var items = [
-        dummyDataa(title: "team1 interview Banana",
-                   date:Calendar.current.date(from: DateComponents(year: 2021, month: 7, day: 1)),
-                   interviewTime: "07:37") ,
-        dummyDataa(title: "team2 interview Banana Melon",
-                   date: Calendar.current.date(from: DateComponents(year: 2022, month: 7, day: 1)),
-                   interviewTime: "32:37"),
-        dummyDataa(title: "team3 interview Melon",
-                   date: Calendar.current.date(from: DateComponents(year: 2023, month: 7, day: 1)),
-                   interviewTime: "12:37")
-
-    ]
-
-    @State var selectedRows = Set<String>()
-
-    @State var isEditing = false
-    @State var showAlert = false
-
-    @State var navigationTitleString = ""
-    @State var searchText = ""
-
-    var searchResults : [dummyDataa] {
-        if searchText.isEmpty {
-            return items
-        } else {
-            return items.filter { $0.title.contains(searchText) }
-        }
-    }
+    @EnvironmentObject var interviewListViewModel: InterviewListViewModel
+    @StateObject var interviewBubbleManager: InterviewBubbleManager = InterviewBubbleManager()
+    @State private var selectedRows = Set<String>()
+    @State private var isEditing = false
+    @State private var showAlert = false
+    @State private var navigationTitleString = ""
+    @State private var searchText = ""
     
     var body: some View {
-
-
         NavigationView {
-
-            VStack{
-                List(selection: $selectedRows) {
-                    ForEach(searchResults, id: \.id) {
-                        one in
-                        VStack(alignment: .leading) {
-                            Text(one.title)
-                                .font(.body)
-
-                            Text(one.date, style: .date)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                        .listRowBackground(Color(UIColor.systemGray6))
-                        
-                    }
-                    
-                    
-
-                }
-                // NavigationView 전체 색상 적용
-                .scrollContentBackground(.hidden) // NavigationView Background적용을 위한 세팅
-                .background(Color.white) // NavigationView 전체 색상
-                .navigationTitle(isEditing ? "\(selectedRows.count)개가 선택됨" : "인터뷰")
-                .navigationBarTitleDisplayMode(.inline)
-
-
-                .toolbar {
-                    if isEditing {
-                        ToolbarItem(placement: .navigationBarLeading) {
-                            Button {
-                                isEditing.toggle()
-                            } label: {
-                                Text("취소")
-                                    .foregroundColor(Color.orange)
+            List(selection: $selectedRows) {
+                ForEach(
+                    0 ..< interviewListViewModel.interviewList.count,
+                    id: \.self
+                ) {  index in
+                    if
+                        let interviewDetail = interviewListViewModel.getEachInterviewDetail(idx: index) {
+                        NavigationLink {
+                            VStack {
+                                InterviewDetailView(
+                                    interviewBubbleManager: interviewBubbleManager,
+                                    interviewIndex: index
+                                )
                             }
-
-                        }
-                    }
-
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button {
-                            
-                            if !isEditing {
-                                isEditing.toggle()
-                            } else if isEditing  {
-                                showAlert.toggle()
-                            }
-
-
                         } label: {
-                            Text(isEditing ? "삭제" : "편집" )
-                                .foregroundColor(Color.orange)
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(interviewDetail.interviewTitle)
+                                        .font(.headline)
+                                        .foregroundColor(.primary)
+                                    
+                                    Text(interviewDetail.date.toString(dateFormat: "yyyy. MM. dd. a HH:mm"))
+                                        .font(.subheadline)
+                                        .foregroundColor(Color(.systemGray))
+                                }
+                                
+                                Spacer()
+                                
+                                Text(interviewDetail.playTime)
+                                    .font(.headline)
+                                    .foregroundColor(Color.pressorSystemGray_dark)
+                                
+                            }
                         }
-                        
-                        
-
+                        .listRowBackground(Color.BackgroundGray_Light)
+                    } else {
+                        Text("NO INTERVIEWS TO SHOW")
                     }
-
-
                 }
-
-
-                //편집 클릭시 멀티셀렉션 돌아가게 해주는 내용
-                .environment(\.editMode, .constant(self.isEditing ? .active : .inactive))
-                .animation(.default, value: isEditing)
-
-
-                ForEach(items, id: \.id) {
-                    one in
-                    VStack(alignment: .leading) {
-                        Text(one.title)
-                            .font(.body)
-
-                        Text(one.date, style: .date)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-
-                    }
+                .onDelete { indexSet in
+                    delete(at: indexSet)
                 }
             }
+            // NavigationView Background적용을 위한 세팅
+            .scrollContentBackground(.hidden)
+            .background(Color.white) // NavigationView 전체 색상
+            .navigationTitle("인터뷰")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                EditButton()
+            }
+            //편집 클릭시 멀티셀렉션 돌아가게 해주는 내용
+            .animation(.default, value: isEditing)
             .searchable(text: $searchText, prompt: "Interview 검색")
-            .alert(isPresented: $showAlert) {
-                Alert(title: Text("인터뷰 삭제"),
-                      message: Text("\(selectedRows.count)개의 인터뷰가 삭제됩니다"),
-                      primaryButton: .destructive(Text("삭제"),
-                                                  action: {
-                    delete()
-                    isEditing.toggle()
-                    
-                } ) ,
-                      secondaryButton: .cancel(Text("취소"))
-                )
-            }
-            
-
-
         }
-
-
-
     }
 
-
-    func swipeDelete(indexSet: IndexSet) {
-        items.remove(atOffsets: indexSet)
+    private func delete(at offsets: IndexSet) {
+        interviewListViewModel.interviewList.remove(atOffsets: offsets)
     }
-    
-    func delete() {
-        print("반복")
-        for item in selectedRows {
-            print(item)
-            if let index = items.lastIndex(where: { $0.id == item }) {
-                items.remove(at: index)
-                
-            }
-        }
-
-    }
-
 }
 
 struct InterviewListView_Previews: PreviewProvider {
     static var previews: some View {
         InterviewListView()
+            .environmentObject(InterviewListViewModel())
     }
 }
 

--- a/Pressor/Pressor/Views/InterviewViews/InterviewModals/InterviewDetailChatEditModalView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewModals/InterviewDetailChatEditModalView.swift
@@ -9,12 +9,14 @@ import SwiftUI
 
 struct InterviewDetailChatEditModalView: View {
     @ObservedObject var interviewBubbleManager: InterviewBubbleManager
+    @EnvironmentObject var interviewListViewModel: InterviewListViewModel
     @Environment(\.dismiss) var dismiss
     @State private var interviewDescription: String = ""
     @Binding var isInterviewDetailChatEditModalViewDisplayed: Bool
     @FocusState var isTextEditorDisplayed: Bool
     
     let transcriptIndex: Int
+    let interviewIdx: Int
     
     var body: some View {
         NavigationView {
@@ -46,9 +48,9 @@ struct InterviewDetailChatEditModalView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
                         hideKeyboard()
-                        interviewBubbleManager.currentInterview.recordSTT[transcriptIndex] = interviewDescription
+                        interviewListViewModel.interviewList[interviewIdx].recordSTT[transcriptIndex] = interviewDescription
                         dismiss()
-                        // TODO: RECORD TEXT UPDATE HERE
+                        
                     } label: {
                         Text("완료")
                     }
@@ -56,7 +58,7 @@ struct InterviewDetailChatEditModalView: View {
             }
         }
         .onAppear {
-            self.interviewDescription = interviewBubbleManager.currentInterview.recordSTT[transcriptIndex]
+            self.interviewDescription = interviewListViewModel.interviewList[interviewIdx].recordSTT[transcriptIndex]
         }
         .onTapGesture {
             hideKeyboard()

--- a/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
+++ b/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
@@ -18,7 +18,6 @@ struct MainRecordView: View {
     @State var showModal = false
     @State var scriptAdded: Bool = false
     @State var navigateToNextView = false
-    @State var isShownInterviewRecordingView = false
     @State var countSec: Int = 0
     @State var timerCount : Timer?
     @State var isTimerCounting: Bool = false
@@ -55,7 +54,7 @@ struct MainRecordView: View {
                                                 timerCount?.invalidate()
                                                 // MARK: 대본이 있다면 추가시키는 로직
                                                 vm.interview.script = interviewViewModel.getScript()
-                                                self.isShownInterviewRecordingView.toggle()
+                                                routingManager.isRecordViewDisplayed.toggle()
                                                 isTimerCounting.toggle()
                                             }
                                         })
@@ -65,11 +64,11 @@ struct MainRecordView: View {
                                     Image("mic_button")
                                         .padding(.bottom, 40)
                                 }
-                                .fullScreenCover(isPresented: $isShownInterviewRecordingView) {
+                                .fullScreenCover(isPresented: $routingManager.isRecordViewDisplayed) {
                                     if scriptAdded {
-                                        InterviewRecordingScriptView(vm: vm, isShownInterviewRecordingView: $isShownInterviewRecordingView)
+                                        InterviewRecordingScriptView(vm: vm)
                                     } else {
-                                        InterviewRecordingView(vm: vm, isShownInterviewRecordingView: $isShownInterviewRecordingView)
+                                        InterviewRecordingView(vm: vm)
                                     }
                                 }
                             }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->

- #71 

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
1. Interview, Record 타입의 id 를 상수형으로 변경
    - decode가 가능한 변수로 수정하여 identifiable 한 UI 구현 
2. InterviewListViewModel
    - list의 count를 기준으로 메소드를 실행하게 하고 Optional Return 타입으로 분기 처리
    - Interview를 제거해도 Crash 나지 않도록 구현
3. Array<CustomType> Decode
    - 배열 자체를 문자열로 encode 하고 해당 문자열을 [Element].self 타입으로 decode 할 수 있는 확장 구현
    - [Interview] 의 UserDefaults 저장 성공
4. 각 View가 참조하고 있는 값들의 재정리
    - Recording 시점에 voiceViewModel이 관리하는 interview 인스턴스는 정보를 입력하는 순간 UserDefaults의 List로 append
    - 이후 InterviewList에서 Interview를 조회할 때는 순수 UserDefault의 List를 참조하게 하여 객체 책임 분리

## 주요 로직(Optional)
```swift
extension Array: RawRepresentable where Element: Codable {
    public init?(rawValue: String) {
        guard
            let data = rawValue.data(using: .utf8),
            let result = try? JSONDecoder().decode([Element].self, from: data) else {
            return nil
        }
        self = result
    }
    
    public var rawValue: String {
        guard
            let data = try? JSONEncoder().encode(self),
            let result = String(data: data, encoding: .utf8) else {
            return "[]"
        }
        return result
    }
}

```
