### PR TITLE
Fix/#77 fix interview init timing

### DIFF
--- a/Pressor/Pressor.xcodeproj/project.pbxproj
+++ b/Pressor/Pressor.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		7E6E395D2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6E395C2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift */; };
 		7E6E395F2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6E395E2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift */; };
 		7E74F30B2A0CDB4700D03AF3 /* RoutingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E74F30A2A0CDB4700D03AF3 /* RoutingManager.swift */; };
+		7E7796AF2A14A8E00037610E /* InterviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7796AE2A14A8E00037610E /* InterviewListView.swift */; };
 		7EC865E72A0501810041B31A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC865E62A0501810041B31A /* Constants.swift */; };
 		7EC865EA2A05044C0041B31A /* View+DismissKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC865E92A05044C0041B31A /* View+DismissKeyboard.swift */; };
 		7EC865EC2A050A2C0041B31A /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC865EB2A050A2C0041B31A /* Color+.swift */; };
@@ -40,7 +41,6 @@
 		7EDEB0D72A011E0E00176D72 /* RecordBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0D62A011E0E00176D72 /* RecordBubble.swift */; };
 		7EDEB0D92A011E1500176D72 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0D82A011E1500176D72 /* Record.swift */; };
 		7EDEB0DB2A011E2A00176D72 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */; };
-		AC4F69E82A024ECD0035FC59 /* InterviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */; };
 		C9089BF02A0E7E9A00AE57DC /* AddScriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9089BEF2A0E7E9A00AE57DC /* AddScriptView.swift */; };
 		C9089BF22A0E7EA500AE57DC /* EditScriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9089BF12A0E7EA500AE57DC /* EditScriptView.swift */; };
 		C918E6E02A09CC720074BAF0 /* AddScriptModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C918E6DF2A09CC720074BAF0 /* AddScriptModalView.swift */; };
@@ -76,6 +76,7 @@
 		7E6E395C2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewDetailEditModalView.swift; sourceTree = "<group>"; };
 		7E6E395E2A03A28D0073CDD0 /* InterviewDetailChatEditModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewDetailChatEditModalView.swift; sourceTree = "<group>"; };
 		7E74F30A2A0CDB4700D03AF3 /* RoutingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingManager.swift; sourceTree = "<group>"; };
+		7E7796AE2A14A8E00037610E /* InterviewListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterviewListView.swift; sourceTree = "<group>"; };
 		7EC865E62A0501810041B31A /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		7EC865E92A05044C0041B31A /* View+DismissKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+DismissKeyboard.swift"; sourceTree = "<group>"; };
 		7EC865EB2A050A2C0041B31A /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
@@ -91,7 +92,6 @@
 		7EDEB0D62A011E0E00176D72 /* RecordBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBubble.swift; sourceTree = "<group>"; };
 		7EDEB0D82A011E1500176D72 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		7EDEB0DA2A011E2A00176D72 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
-		AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewListView.swift; sourceTree = "<group>"; };
 		C9089BEF2A0E7E9A00AE57DC /* AddScriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddScriptView.swift; sourceTree = "<group>"; };
 		C9089BF12A0E7EA500AE57DC /* EditScriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditScriptView.swift; sourceTree = "<group>"; };
 		C918E6DF2A09CC720074BAF0 /* AddScriptModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddScriptModalView.swift; sourceTree = "<group>"; };
@@ -262,7 +262,7 @@
 				7E3B3E592A0A0D6700DCA93A /* InterviewDetailView.swift */,
 				C957BB9E2A027D05006649A8 /* InterviewRecordingView.swift */,
 				60F0BC112A0E859600B6B539 /* InterviewRecordingScriptView.swift */,
-				AC4F69E72A024ECD0035FC59 /* InterviewListView.swift */,
+				7E7796AE2A14A8E00037610E /* InterviewListView.swift */,
 			);
 			path = InterviewViews;
 			sourceTree = "<group>";
@@ -342,6 +342,7 @@
 				7E74F30B2A0CDB4700D03AF3 /* RoutingManager.swift in Sources */,
 				C9F1C3232A10BABD002B9C9C /* SettingView.swift in Sources */,
 				7EDEB0BF2A011B4B00176D72 /* ContentView.swift in Sources */,
+				7E7796AF2A14A8E00037610E /* InterviewListView.swift in Sources */,
 				608D9D7F2A022F5E001E8E3C /* MainTestView.swift in Sources */,
 				C918E6E02A09CC720074BAF0 /* AddScriptModalView.swift in Sources */,
 				608D9D6C2A013AF0001E8E3C /* InterviewRecordingTestView.swift in Sources */,
@@ -363,7 +364,6 @@
 				7EDEB0D32A011DE800176D72 /* AddRecordScriptModalView.swift in Sources */,
 				C9C7BC822A021F1F005E473B /* AudioVisualizerView.swift in Sources */,
 				C9089BF22A0E7EA500AE57DC /* EditScriptView.swift in Sources */,
-				AC4F69E82A024ECD0035FC59 /* InterviewListView.swift in Sources */,
 				7E392C792A0E092A00130338 /* InterviewBubbleManager.swift in Sources */,
 				7EDEB0DB2A011E2A00176D72 /* RecordViewModel.swift in Sources */,
 				7E6E395D2A03A16C0073CDD0 /* InterviewDetailEditModalView.swift in Sources */,
@@ -514,7 +514,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pressor/Preview Content\"";
-				DEVELOPMENT_TEAM = 3NP4Z3WZ94;
+				DEVELOPMENT_TEAM = 67M6ZS7KS6;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pressor/Info.plist;
@@ -549,7 +549,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pressor/Preview Content\"";
-				DEVELOPMENT_TEAM = 3NP4Z3WZ94;
+				DEVELOPMENT_TEAM = 67M6ZS7KS6;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pressor/Info.plist;

--- a/Pressor/Pressor/Models/Interview.swift
+++ b/Pressor/Pressor/Models/Interview.swift
@@ -22,3 +22,9 @@ struct Interview: Identifiable, Codable {
         Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: .init(title: "", description: ""))
     }
 }
+
+extension Interview: Equatable {
+    static func ==(lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/Pressor/Pressor/PressorApp.swift
+++ b/Pressor/Pressor/PressorApp.swift
@@ -10,19 +10,37 @@ import SwiftUI
 @main
 struct PressorApp: App {
     @StateObject var routeManager: RoutingManager = .init()
-    @StateObject var voiceViewModel: VoiceViewModel = .init(interview: .getDummyInterview())
+    @StateObject var voiceViewModel: VoiceViewModel = .init(interview: .getInitInterview())
     @StateObject var interviewListViewModel: InterviewListViewModel = .init()
     @ObservedObject var permissionManager: PermissionManager = .init()
     
     var body: some Scene {
         WindowGroup {
-            MainRecordView(vm: voiceViewModel)
+            MainRecordView()
                 .environmentObject(routeManager)
                 .environmentObject(interviewListViewModel)
+                .environmentObject(voiceViewModel)
                 .onAppear {
                     permissionManager.requestAudioPermission()
                     permissionManager.requestRecordingPermission()
                     permissionManager.requestSpeechRecognizerPermission()
+                    voiceViewModel.initInterview()
+                }
+                .onChange(of: voiceViewModel.isSTTCompleted) { newValue in
+                    if newValue {
+                        let completedArray = voiceViewModel.getTranscribeArray()
+                        interviewListViewModel.completedInterview.recordSTT = completedArray
+                        if
+                            let index = interviewListViewModel.interviewList.firstIndex(of: interviewListViewModel.completedInterview) {
+                            interviewListViewModel.interviewList[index] = interviewListViewModel.completedInterview
+                            voiceViewModel.isSTTCompleted = false
+                        }
+                    }
+                }
+                .onChange(of: interviewListViewModel.isUpdatingDetails) { newValue in
+                    if newValue {
+                        interviewListViewModel.updateInterviewDetails()
+                    }
                 }
         }
     }

--- a/Pressor/Pressor/ViewModels/InterviewListViewModel.swift
+++ b/Pressor/Pressor/ViewModels/InterviewListViewModel.swift
@@ -6,14 +6,23 @@
 //
 
 import SwiftUI
+import Combine
 
 final class InterviewListViewModel: ObservableObject {
-    @AppStorage(Constants.USERDEFAULTS_INTERVIEWS_KEY) var interviewList: [Interview] = []
-    @Published var currentInterview: Interview = .getDummyInterview()
+    @AppStorage(Constants.USERDEFAULTS_INTERVIEWS_KEY)
+    var interviewList: [Interview] = []
+    
+    @Published var completedInterview: Interview = .getInitInterview()
+    @Published var isUpdatingDetails: Bool = false
+    
+    @Published var interviewTitle: String = ""
+    @Published var userName: String = ""
+    @Published var userEmail: String = ""
+    @Published var userPhoneNumber: String = ""
     
     public func getEachInterview(idx: Int) -> Interview? {
         if interviewList.count > 0 {
-            return self.interviewList[idx]
+            return self.interviewList[safe: idx]
         } else {
             return nil
         }
@@ -21,7 +30,7 @@ final class InterviewListViewModel: ObservableObject {
     
     public func getEachInterviewDetail(idx: Int) -> InterviewDetail? {
         if interviewList.count > 0 {
-            return self.interviewList[idx].details
+            return self.interviewList[safe: idx]?.details
         } else {
             return nil
         }
@@ -29,9 +38,31 @@ final class InterviewListViewModel: ObservableObject {
     
     public func getEachInterviewRecordList(idx: Int) -> [Record]? {
         if interviewList.count > 0 {
-            return self.interviewList[idx].records
+            return self.interviewList[safe: idx]?.records
         } else {
             return nil
         }
+    }
+    
+    public func updateInterviewDetails() {
+        self.completedInterview.details.interviewTitle = interviewTitle
+        self.completedInterview.details.userName = userName
+        self.completedInterview.details.userEmail = userEmail
+        self.completedInterview.details.userPhoneNumber = userPhoneNumber
+        initState()
+    }
+    
+    public func updateState(with interview: Interview) {
+        self.interviewTitle = interview.details.interviewTitle
+        self.userName = interview.details.userName
+        self.userEmail = interview.details.userEmail
+        self.userPhoneNumber = interview.details.userPhoneNumber
+    }
+    
+    private func initState() {
+        interviewTitle = ""
+        userName = ""
+        userEmail = ""
+        userPhoneNumber = ""
     }
 }

--- a/Pressor/Pressor/Views/InterviewViews/InterviewDetailView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewDetailView.swift
@@ -82,7 +82,7 @@ struct InterviewDetailView: View {
             
             // TODO: GET Record List Here
             transferableScripts.removeAll()
-            makeTransferableScripts()
+            makeTransferableScripts()   
         }
         .navigationTitle(interviewListViewModel.getEachInterviewDetail(idx: interviewIndex)?.interviewTitle ?? "DELETED")
         .navigationBarTitleDisplayMode(.inline)

--- a/Pressor/Pressor/Views/InterviewViews/InterviewListView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewListView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct InterviewListView: View {
     @EnvironmentObject var interviewListViewModel: InterviewListViewModel
     @StateObject var interviewBubbleManager: InterviewBubbleManager = InterviewBubbleManager()
+    @EnvironmentObject var voiceViewModel: VoiceViewModel
     @State private var selectedRows = Set<String>()
     @State private var isEditing = false
     @State private var showAlert = false
@@ -72,6 +73,9 @@ struct InterviewListView: View {
             //편집 클릭시 멀티셀렉션 돌아가게 해주는 내용
             .animation(.default, value: isEditing)
             .searchable(text: $searchText, prompt: "Interview 검색")
+        }
+        .onChange(of: voiceViewModel.interviewList) { newValue in
+            interviewListViewModel.interviewList = newValue
         }
     }
 

--- a/Pressor/Pressor/Views/InterviewViews/InterviewListView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewListView.swift
@@ -47,13 +47,24 @@ struct InterviewListView: View {
                                 
                                 Spacer()
                                 
-                                Text(interviewDetail.playTime)
-                                    .font(.headline)
-                                    .foregroundColor(Color.pressorSystemGray_dark)
-                                
+                                if
+                                    let interview = interviewListViewModel.getEachInterview(idx: index) {
+                                    if interview.recordSTT.isEmpty {
+                                        Text("변환 중")
+                                            .foregroundColor(.PressorOrange)
+                                        
+                                        ProgressView()
+                                            .progressViewStyle(CircularProgressViewStyle(tint: Color.pressorSystemGray_dark))
+                                    } else {
+                                        Text(interviewDetail.playTime)
+                                            .font(.headline)
+                                            .foregroundColor(Color.pressorSystemGray_dark)
+                                    }
+                                }
                             }
                         }
                         .listRowBackground(Color.BackgroundGray_Light)
+                        .disabled(interviewListViewModel.getEachInterview(idx: index)?.recordSTT.isEmpty ?? false)
                     } else {
                         Text("NO INTERVIEWS TO SHOW")
                     }
@@ -74,20 +85,9 @@ struct InterviewListView: View {
             .animation(.default, value: isEditing)
             .searchable(text: $searchText, prompt: "Interview 검색")
         }
-        .onChange(of: voiceViewModel.interviewList) { newValue in
-            interviewListViewModel.interviewList = newValue
-        }
     }
 
     private func delete(at offsets: IndexSet) {
         interviewListViewModel.interviewList.remove(atOffsets: offsets)
     }
 }
-
-struct InterviewListView_Previews: PreviewProvider {
-    static var previews: some View {
-        InterviewListView()
-            .environmentObject(InterviewListViewModel())
-    }
-}
-

--- a/Pressor/Pressor/Views/InterviewViews/InterviewModals/InterviewDetailChatEditModalView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewModals/InterviewDetailChatEditModalView.swift
@@ -58,7 +58,7 @@ struct InterviewDetailChatEditModalView: View {
             }
         }
         .onAppear {
-            self.interviewDescription = interviewListViewModel.interviewList[interviewIdx].recordSTT[transcriptIndex]
+            self.interviewDescription = interviewListViewModel.getEachInterview(idx: interviewIdx)?.recordSTT[safe: transcriptIndex] ?? ""
         }
         .onTapGesture {
             hideKeyboard()

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingScriptView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct InterviewRecordingScriptView: View {
-    @ObservedObject var vm: VoiceViewModel
+    @EnvironmentObject var vm: VoiceViewModel
     @EnvironmentObject var routingManager: RoutingManager
     
     @State private var isShowingList = false
@@ -26,7 +26,6 @@ struct InterviewRecordingScriptView: View {
     @State private var isShowingTopImage = true
 //    @Binding var isShownInterviewRecordingView: Bool
     @State var isShowingCancelAlert = false
-    
     
     // 타이머 시간 포맷
     func formattedDuration(_ duration: TimeInterval) -> String {
@@ -187,12 +186,9 @@ struct InterviewRecordingScriptView: View {
                             destination: InterviewDetailEditModalView(
                                 isDetailChanging: .constant(false),
                                 interview: vm.interview
-                            )
-                            .onAppear {
-                                vm.isSTTCompleted = false
-                            },
+                            ),
                             label: {
-                                Text(vm.isSTTCompleted ? "완료" : "음성 변환중")
+                                Text("완료")
                                     .font(.headline)
                                 // 녹음 중일때 -> 회색, 녹음 일시정지일때 -> 빨간색
                                     .foregroundColor(!isPaused ? Color.BackgroundGray_Dark : Color.red)
@@ -212,7 +208,7 @@ struct InterviewRecordingScriptView: View {
                         )
                         .navigationTitle("뒤로")
                         .navigationBarHidden(true)
-                        .disabled(isRecording || !vm.isSTTCompleted)
+                        .disabled(isRecording)
                     } // HStack
                     ZStack {
                         ScrollView(.vertical, showsIndicators: false) {
@@ -376,11 +372,3 @@ struct InterviewRecordingScriptView: View {
     } // body
 } // struct
 
-struct InterviewRecordingScriptView_Previews: PreviewProvider {
-    static var previews: some View {
-        InterviewRecordingScriptView(
-            vm: VoiceViewModel(
-                interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: Script(title: "", description: "")))
-        )
-    }
-}

--- a/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
+++ b/Pressor/Pressor/Views/InterviewViews/InterviewRecordingView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct InterviewRecordingView: View {
     @EnvironmentObject var routingManager: RoutingManager
-    @ObservedObject var vm: VoiceViewModel
+    @EnvironmentObject var vm: VoiceViewModel
     
     @State private var isDetailChanging: Bool = false
     @State private var isShowingList = false
@@ -26,7 +26,6 @@ struct InterviewRecordingView: View {
     @State private var initChevronOffsetYValue = CGFloat.zero
     @State private var isShowingTopImage = true
     @State var isShowingCancelAlert = false
-    @State var urls: [URL] = []
     
     // 타이머 시간 포맷
     func formattedDuration(_ duration: TimeInterval) -> String {
@@ -188,12 +187,9 @@ struct InterviewRecordingView: View {
                             destination: InterviewDetailEditModalView(
                                 isDetailChanging: .constant(false),
                                 interview: vm.interview
-                            )
-                            .onAppear {
-                                vm.isSTTCompleted = false
-                            },
+                            ),
                             label: {
-                                Text(vm.isSTTCompleted ? "완료" : "음성 변환중")
+                                Text("완료")
                                     .font(.headline)
                                 // 녹음 중일때 -> 회색, 녹음 일시정지일때 -> 빨간색
                                     .foregroundColor(!isPaused ? Color.BackgroundGray_Dark : Color.red)
@@ -209,18 +205,11 @@ struct InterviewRecordingView: View {
                                 .onEnded { _ in
                                     vm.interview.records = vm.recordings
                                     vm.interview.details.playTime = formattedDuration(duration)
-                                    
-                                    // urls에 저장된 음성파일의 모든 fileURL추가
-                                    for record in vm.recordings {
-                                        urls.append(record.fileURL)
-                                    }
-                                    vm.transURLs(urls: urls)
-                                    
                                 }
                         )
                         .navigationTitle("뒤로")
                         .navigationBarHidden(true)
-                        .disabled(isRecording || !vm.isSTTCompleted)
+                        .disabled(isRecording)
                     } // HStack
                     // 화자 전환 기능
                     RoundedRectangle(cornerRadius: 44)
@@ -351,11 +340,3 @@ struct InterviewRecordingView: View {
     } // body
 } // struct
 
-struct InterviewRecordingView_Previews: PreviewProvider {
-    static var previews: some View {
-        InterviewRecordingView(
-            vm: VoiceViewModel(
-                interview: Interview(details: InterviewDetail(interviewTitle: "", userName: "", userEmail: "", userPhoneNumber: "", date: Date(), playTime: ""), records: [], recordSTT: [], script: Script(title: "", description: "")))
-        )
-    }
-}

--- a/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
+++ b/Pressor/Pressor/Views/RecordViews/MainRecordView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct MainRecordView: View {
     @Environment(\.presentationMode) private var presentationMode
     @EnvironmentObject var routingManager: RoutingManager
-    @ObservedObject var vm: VoiceViewModel
+    @EnvironmentObject var vm: VoiceViewModel
     @StateObject var interviewViewModel = InterviewViewModel()
     
     @State var isSheetShowing: Bool = false
@@ -66,9 +66,9 @@ struct MainRecordView: View {
                                 }
                                 .fullScreenCover(isPresented: $routingManager.isRecordViewDisplayed) {
                                     if scriptAdded {
-                                        InterviewRecordingScriptView(vm: vm)
+                                        InterviewRecordingScriptView()
                                     } else {
-                                        InterviewRecordingView(vm: vm)
+                                        InterviewRecordingView()
                                     }
                                 }
                             }
@@ -177,14 +177,8 @@ struct MainRecordView: View {
             .accentColor(.orange)
             .onAppear {
                 UITabBar.appearance().scrollEdgeAppearance = .init()
-                vm.initInterview()
             }
         }
     }
 }
 
-struct MainRecordView_Previews: PreviewProvider {
-    static var previews: some View {
-        MainRecordView(vm: VoiceViewModel(interview: .getDummyInterview()))
-    }
-}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->

- #77 

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- `.onChange(of:) { }` 메소드를 WindowGroup의 첫 뷰가 갖게끔하여 데이터 변동에 직접 접근 및 수정이 가능하도록 시점 제어
- TextField의 값이 업데이트 되지 않는 이슈를 ViewModel에서 처리하도록 하여 버그 픽스
